### PR TITLE
Endrer logikk på utledning av ident/aktør-id for journalpost

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostService.kt
@@ -39,19 +39,12 @@ class JournalpostService(
                 }")
                 throw IkkeTilgang()
             } else {
-                val norskIdent: NorskIdent? = when {
-                    parsedJournalpost.brukerType == SafDtos.BrukerType.FNR -> {
-                        safJournalpost.bruker?.id
-                    }
-                    parsedJournalpost.avsenderMottakertype == SafDtos.AvsenderMottakertype.FNR -> {
-                        safJournalpost.avsenderMottaker?.id
-                    }
-                    else -> null
+                val (norskIdent, aktørId) = when {
+                    SafDtos.BrukerType.FNR == parsedJournalpost.brukerType -> safJournalpost.bruker?.id to null
+                    SafDtos.BrukerType.AKTOERID == parsedJournalpost.brukerType -> null to safJournalpost.bruker?.id
+                    SafDtos.AvsenderMottakertype.FNR == parsedJournalpost.avsenderMottakertype -> safJournalpost.avsenderMottaker?.id to null
+                    else -> null to null
                 }
-
-                val aktørId: AktørId? = if (parsedJournalpost.brukerType == SafDtos.BrukerType.AKTOERID) {
-                    safJournalpost.bruker?.id
-                } else null
 
                 val mottattDato = utledMottattDato(parsedJournalpost)
 


### PR DESCRIPTION
Forsikrer at vi kun sender èn ID (NorskIdent eller AktørId) for journalposten.

Med logikken slik den var kunne vi ende opp med både en AktørId og en NorskIdent (AktørId på bruker og NorskIdent på avsenderMottaker som ikke nødvendigvis er samme person) 