### PR TITLE
Endringsperiode validering

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/domenetjenester/mappers/MapTilK9Format.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/domenetjenester/mappers/MapTilK9Format.kt
@@ -132,7 +132,7 @@ internal class MapTilK9Format {
             return Søknad(SøknadId.of(søknadId.toString()), versjon, mottattDato, søker, ytelse)
         }
 
-        private fun List<PeriodeDto>.somK9Perioder() = map {
+        internal fun List<PeriodeDto>.somK9Perioder() = map {
             objectMapper.convertValue<Periode>(fromPeriodeDtoToString(it))
         }
 

--- a/app/src/test/kotlin/no/nav/k9punsj/PleiepengersyktbarnTests.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/PleiepengersyktbarnTests.kt
@@ -280,8 +280,7 @@ class PleiepengersyktbarnTests {
             .bodyToMono(OasPleiepengerSyktBarnFeil::class.java)
             .block()
         assertEquals(HttpStatus.BAD_REQUEST, res.second.statusCode())
-        //9 feil
-        assertEquals(response?.feil?.size, 9)
+        assertEquals(response?.feil?.size, 12)
     }
 
     @Test
@@ -560,8 +559,6 @@ class PleiepengersyktbarnTests {
         assertThat(ytelse.lovbestemtFerie!!.perioder?.get(Periode("2018-12-30/2019-06-20"))?.isSkalHaFerie).isEqualTo(true)
         assertThat(ytelse.lovbestemtFerie!!.perioder?.get(Periode("2019-06-21/2019-10-20"))?.isSkalHaFerie).isEqualTo(false)
         assertThat(ytelse.utenlandsopphold!!.perioder.keys.first()?.iso8601).isEqualTo("2018-12-30/2019-10-20")
-        assertThat(ytelse.infoFraPunsj!!.get().inneholderMedisinskeOpplysninger).isEqualTo(false)
-        assertThat(ytelse.infoFraPunsj!!.get().søknadenInneholderInfomasjonSomIkkeKanPunsjes).isEqualTo(true)
         assertThat(ytelse.søknadInfo!!.get().samtidigHjemme).isEqualTo(true)
         assertThat(ytelse.søknadInfo!!.get().harMedsøker).isEqualTo(true)
         assertThat(ytelse.opptjeningAktivitet.frilanser.jobberFortsattSomFrilans).isEqualTo(true)

--- a/app/src/test/kotlin/no/nav/k9punsj/domenetjenester/mappers/MapTilK9FormatTest.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/domenetjenester/mappers/MapTilK9FormatTest.kt
@@ -1,0 +1,65 @@
+package no.nav.k9punsj.domenetjenester.mappers
+
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.module.kotlin.convertValue
+import no.nav.k9.søknad.felles.type.Periode
+import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
+import no.nav.k9punsj.domenetjenester.mappers.MapTilK9Format.Companion.somK9Perioder
+import no.nav.k9punsj.objectMapper
+import no.nav.k9punsj.rest.web.dto.PeriodeDto
+import no.nav.k9punsj.rest.web.dto.PleiepengerSøknadMottakDto
+import no.nav.k9punsj.rest.web.dto.PleiepengerSøknadVisningDto
+import no.nav.k9punsj.util.LesFraFilUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.*
+
+internal class MapTilK9FormatTest {
+
+    @Test
+    fun `Innenfor perioder i K9`() {
+        val søknad = pleiepengerSyktBarnSøknad()
+        val (ytelse, feil) = søknad.mapTilK9Format(lengrePeriodeIK9)
+        assertThat(feil).isEmpty()
+        assertThat(endringsperioder).hasSameElementsAs(ytelse.endringsperiode)
+        assertThat(endringsperioder).hasSameElementsAs(ytelse.endringsperioderFraJson())
+    }
+
+    @Test
+    fun `Utenfor perioder i K9`() {
+        val søknad = pleiepengerSyktBarnSøknad()
+        val (_, feil) = søknad.mapTilK9Format(korterePeriodeIK9)
+        assertThat(feil).isNotEmpty
+        assertThat(feil).allMatch { it.feilkode == "ugyldigPeriode" }
+    }
+
+    private fun pleiepengerSyktBarnSøknad() : PleiepengerSøknadMottakDto {
+        val søknad = LesFraFilUtil.søknadFraFrontend()
+
+        søknad.replace("soeknadsperiode", mapOf(
+            "fom" to "${søknadsperiode.fom}",
+            "tom" to "${søknadsperiode.tom}"
+        ))
+
+        val dto = objectMapper().convertValue<PleiepengerSøknadVisningDto>(søknad)
+        return MapFraVisningTilEksternFormat.mapTilSendingsformat(dto)
+    }
+
+    private fun PleiepengerSøknadMottakDto.mapTilK9Format(perioderSomFinnesIK9: List<PeriodeDto>) = MapTilK9Format.mapTilEksternFormat(
+        søknad = this,
+        soeknadId = "${UUID.randomUUID()}",
+        journalpostIder = setOf("111111111"),
+        perioderSomFinnesIK9 = perioderSomFinnesIK9
+    ).let { it.first.getYtelse<PleiepengerSyktBarn>() to it.second }
+
+    private companion object {
+        private val søknadsperiode = PeriodeDto(fom = LocalDate.parse("2018-12-30"), tom = LocalDate.parse("2019-09-20"))  // Settes tilbake en måned, opprinnelig "2019-10-20"
+        private val endringsperiode = PeriodeDto(fom = LocalDate.parse("2019-09-21"), tom = LocalDate.parse("2019-10-20"))
+        private val lengrePeriodeIK9 = listOf(endringsperiode.copy(tom = endringsperiode.tom!!.plusMonths(4)))
+        private val korterePeriodeIK9 = listOf(endringsperiode.copy(tom = endringsperiode.tom!!.minusDays(5)))
+        private val endringsperioder = listOf(endringsperiode).somK9Perioder()
+        private fun PleiepengerSyktBarn.endringsperioderFraJson() = (objectMapper().readTree(objectMapper().writeValueAsString(this)).get("endringsperiode") as ArrayNode)
+            .map { Periode(it.asText()) }
+    }
+}

--- a/app/src/test/kotlin/no/nav/k9punsj/innsending/InnsendingMappingTest.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/innsending/InnsendingMappingTest.kt
@@ -27,7 +27,7 @@ internal class InnsendingMappingTest {
         val k9Format = MapTilK9Format.mapTilEksternFormat(
             søknad = MapFraVisningTilEksternFormat.mapTilSendingsformat(dto),
             soeknadId = "${UUID.randomUUID()}",
-            hentPerioderSomFinnesIK9 = emptyList(),
+            perioderSomFinnesIK9 = emptyList(),
             journalpostIder = setOf(IdGenerator.nesteId(), IdGenerator.nesteId())
         ).first
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dusseldorf-ktor.version>1.4.1.4754df6</dusseldorf-ktor.version>
         <k9-rapid.version>1.31aa518</k9-rapid.version>
 		<k9-sak.version>3.1.28</k9-sak.version>
-        <k9-format.version>5.4.0</k9-format.version>
+        <k9-format.version>5.4.16</k9-format.version>
         <de.huxhorn.sulky.ulid.version>8.2.0</de.huxhorn.sulky.ulid.version>
         <mockk.version>1.11.0</mockk.version>
         <jsonassert.version>1.5.0</jsonassert.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dusseldorf-ktor.version>1.4.1.4754df6</dusseldorf-ktor.version>
         <k9-rapid.version>1.31aa518</k9-rapid.version>
 		<k9-sak.version>3.1.28</k9-sak.version>
-        <k9-format.version>5.4.16</k9-format.version>
+        <k9-format.version>5.4.17</k9-format.version>
         <de.huxhorn.sulky.ulid.version>8.2.0</de.huxhorn.sulky.ulid.version>
         <mockk.version>1.11.0</mockk.version>
         <jsonassert.version>1.5.0</jsonassert.version>


### PR DESCRIPTION
- Oppdatert til k9-format `5.4.17`
- Bruker validator hvor vi sender inn perioder vi finner i K9 (og fjerner å sette endringsperioder == perioder vi finner i K9 - de utledes nå som en del av k9-format lib'en)
- Fjerner bruk av deprecated `InfoFraPunsj` - dette settes nå på hver enkelt journalpost etter #318 
- Ved opprettelse av journalføringsoppgave sjekker vi nå at journalpost finnes og at det er inngående journalpost før det opprettes oppgave.