### PR TITLE
Endret saf scope fra clientId til azureator. Oppdatert saf baseurl.

### DIFF
--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -61,9 +61,9 @@ spec:
     - name: NAIS_STS_TOKEN_ENDPOINT
       value: https://security-token-service.nais.preprod.local/rest/v1/sts/token
     - name: SAF_BASE_URL
-      value: https://saf-q1.nais.preprod.local
+      value: https://saf-q1.dev.intern.nav.no
     - name: SAF_HENTE_JOURNALPOST_SCOPES
-      value: c7adbfbb-1b1e-41f6-9b7a-af9627c04998/.default
+      value: api://dev-fss.teamdokumenthandtering.saf/.default
     - name: PDL_BASE_URL
       value: https://pdl-api.nais.preprod.local/graphql
     - name: PDL_SCOPE
@@ -71,7 +71,7 @@ spec:
     - name: GOSYS_BASE_URL
       value: https://oppgave.nais.preprod.local
     - name: SAF_HENTE_DOKUMENT_SCOPES
-      value: c7adbfbb-1b1e-41f6-9b7a-af9627c04998/.default
+      value: api://dev-fss.teamdokumenthandtering.saf/.default
     - name: KAFKA_BOOTSTRAP_SERVERS
       value: b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443
     - name: DEFAULTDS_USERNAME

--- a/nais/prod-fss.yml
+++ b/nais/prod-fss.yml
@@ -61,9 +61,9 @@ spec:
     - name: NAIS_STS_TOKEN_ENDPOINT
       value: https://security-token-service.nais.adeo.no/rest/v1/sts/token
     - name: SAF_BASE_URL
-      value: https://saf.nais.adeo.no
+      value: https://saf.intern.nav.no
     - name: SAF_HENTE_JOURNALPOST_SCOPES
-      value: feb9588b-a3d6-4d2f-8809-97284046ae72/.default
+      value: api://prod-fss.teamdokumenthandtering.saf/.default
     - name: PDL_BASE_URL
       value: https://pdl-api.nais.adeo.no/graphql
     - name: PDL_SCOPE
@@ -71,7 +71,7 @@ spec:
     - name: GOSYS_BASE_URL
       value: https://oppgave.nais.adeo.no
     - name: SAF_HENTE_DOKUMENT_SCOPES
-      value: feb9588b-a3d6-4d2f-8809-97284046ae72/.default
+      value: api://prod-fss.teamdokumenthandtering.saf/.default
     - name: KAFKA_BOOTSTRAP_SERVERS
       value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
     - name: DEFAULTDS_USERNAME


### PR DESCRIPTION
Saf har migrert fra aad-iac til azureator. 
ClientId kan endre seg hvis vi av en eller annen grunn må slette nåværende azureator config. Denne endringen vil redusere risiko for at saf klienten deres feiler på det.

Ta gjerne noen testkall i dev før dere går til prod.