### PR TITLE
Støtter fagsakYtelseType ved sjekk på om journalpost skal til k9-sak.

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/journalpost/Journalpost.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/journalpost/Journalpost.kt
@@ -26,7 +26,7 @@ data class Journalpost(
     )
 }
 
-fun Journalpost?.utledeFagsakYtelseType(): FagsakYtelseType {
+fun Journalpost?.utledeFagsakYtelseType(fagsakYtelseType: FagsakYtelseType? = null): FagsakYtelseType {
     return if (this == null) {
         logger.info("Journalpost er null. Defaulter til ${FagsakYtelseType.PLEIEPENGER_SYKT_BARN.navn}")
         FagsakYtelseType.PLEIEPENGER_SYKT_BARN
@@ -37,13 +37,18 @@ fun Journalpost?.utledeFagsakYtelseType(): FagsakYtelseType {
                 logger.info("Ytelse på journalpost er null. Defaulter til ${FagsakYtelseType.PLEIEPENGER_SYKT_BARN.navn}")
                 pleiepengerSyktBarn
             }
-            no.nav.k9punsj.db.datamodell.FagsakYtelseType.OMSORGSPENGER.kode == this.ytelse -> {
-                val type = FagsakYtelseType.OMSORGSPENGER
+            no.nav.k9punsj.db.datamodell.FagsakYtelseType.PLEIEPENGER_SYKT_BARN.kode == this.ytelse -> {
+                val type = FagsakYtelseType.PLEIEPENGER_SYKT_BARN
                 logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)
                 type
             }
-            no.nav.k9punsj.db.datamodell.FagsakYtelseType.PLEIEPENGER_SYKT_BARN.kode == this.ytelse -> {
-                val type = FagsakYtelseType.PLEIEPENGER_SYKT_BARN
+            no.nav.k9punsj.db.datamodell.FagsakYtelseType.UKJENT.kode == this.ytelse -> {
+                val type = fagsakYtelseType ?: throw IllegalStateException("Ikke støttet journalpost: $this")
+                logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)
+                type
+            }
+            no.nav.k9punsj.db.datamodell.FagsakYtelseType.OMSORGSPENGER.kode == this.ytelse -> {
+                val type = FagsakYtelseType.OMSORGSPENGER
                 logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)
                 type
             }

--- a/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
@@ -226,7 +226,7 @@ internal class JournalpostRoutes(
                     journalpostId = dto.journalpostId,
                     periode = null, // Utledes fra journalposten i Punsjbollen
                     correlationId = coroutineContext.hentCorrelationId(),
-                    fagsakYtelseType = hentHvisJournalpostMedId.utledeFagsakYtelseType()
+                    fagsakYtelseType = hentHvisJournalpostMedId.utledeFagsakYtelseType(dto.fagsakYtelseType)
                 )
 
                 if (punsjbolleRuting == PunsjbolleRuting.K9Sak || punsjbolleRuting == PunsjbolleRuting.Infotrygd) {

--- a/app/src/main/kotlin/no/nav/k9punsj/rest/web/Innsending.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/rest/web/Innsending.kt
@@ -1,6 +1,7 @@
 package no.nav.k9punsj.rest.web
 
 import kotlinx.coroutines.reactive.awaitFirst
+import no.nav.k9.kodeverk.behandling.FagsakYtelseType
 import no.nav.k9punsj.brev.DokumentbestillingDto
 import no.nav.k9punsj.db.datamodell.NorskIdent
 import no.nav.k9punsj.rest.web.dto.*
@@ -56,6 +57,7 @@ data class PunsjBolleDto(
     val barnIdent: NorskIdentDto?,
     val annenPart: NorskIdentDto?,
     val journalpostId: JournalpostIdDto,
+    val fagsakYtelseType: FagsakYtelseType? = null, // TODO: 04/03/2022 Fjern nullable etter lasnsering
 )
 
 data class SettPåVentDto(


### PR DESCRIPTION
Hvis ytelse på journalpost er UKJENT bruker vi innsendt fagsakYtelseType på request til å utlede ytelse.
FagsakYtelseType fra frontend utledes fra hvilket ytelse/dokumentType som er valgt i frontend.