### PR TITLE
Refaktorerer og fikser felt for barn i oms-ma.

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneRoutes.kt
@@ -6,7 +6,6 @@ import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
-import no.nav.k9punsj.utils.ServerRequestUtils.mapNySøknad
 import no.nav.k9punsj.utils.ServerRequestUtils.mapSendSøknad
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
@@ -104,6 +103,9 @@ internal class OmsorgspengerMidlertidigAleneRoutes(
             }
         }
     }
+
+    internal suspend fun ServerRequest.mapNySøknad() =
+        body(BodyExtractors.toMono(NyOmsMASøknad::class.java)).awaitFirst()
 
     private fun ServerRequest.søknadId(): String = pathVariable(SøknadIdKey)
 

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneSøknadDto.kt
@@ -11,6 +11,13 @@ import no.nav.k9punsj.objectMapper
 import java.time.LocalDate
 import java.time.LocalTime
 
+data class NyOmsMASøknad(
+    val norskIdent: String,
+    val journalpostId: String,
+    val annenPart: String? = null,
+    val barn: List<OmsorgspengerMidlertidigAleneSøknadDto.BarnDto>
+)
+
 data class OmsorgspengerMidlertidigAleneSøknadDto(
     val soeknadId: String,
     val soekerId: String? = null,


### PR DESCRIPTION
- Refaktorerer felles() funksjon. Sender kun inn journalpostId i stedetfor nySøknad objekt.
- Legger på info om barn i funksjonen førsteInnsendingOmsMA().
- Oppretter og bruker eget objekt for ny søknad om oms-ma.
- Refaktorerer nySøknad servicemetode for å opprette fagsak pr. barn.
- Tilpasser test for å teste ønsket oppførsel.