### PR TITLE
Utelukker pleietrengende fra opprettelse av sak.

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/punsjbollen/RestPunsjbolleService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/punsjbollen/RestPunsjbolleService.kt
@@ -247,10 +247,10 @@ class RestPunsjbolleService(
                 require(journalpostId != null || periode != null) {
                     "Må sette minst en av journalpostId og periode"
                 }
-                //TODO: Deaktivert foreløpig.
-                /*require(pleietrengende != null || annenPart != null) {
+
+                require(pleietrengende != null || annenPart != null) {
                     "Må sette minst en av pleietrengende og annenPart"
-                }*/
+                }
             }
         }
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/punsjbollen/RestPunsjbolleService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/punsjbollen/RestPunsjbolleService.kt
@@ -247,9 +247,10 @@ class RestPunsjbolleService(
                 require(journalpostId != null || periode != null) {
                     "Må sette minst en av journalpostId og periode"
                 }
-                require(pleietrengende != null || annenPart != null) {
+                //TODO: Deaktivert foreløpig.
+                /*require(pleietrengende != null || annenPart != null) {
                     "Må sette minst en av pleietrengende og annenPart"
-                }
+                }*/
             }
         }
 

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
@@ -76,7 +76,15 @@ class OmsorgspengerMidlertidigAleneService(
 
     internal suspend fun nySøknad(request: ServerRequest, nyOmsMASøknad: NyOmsMASøknad): ServerResponse {
         //oppretter sak i k9-sak hvis det ikke finnes fra før
-        if (nyOmsMASøknad.barn.isNotEmpty()) {
+        punsjbolleService.opprettEllerHentFagsaksnummer(
+            søker = nyOmsMASøknad.norskIdent,
+            annenPart = nyOmsMASøknad.annenPart,
+            journalpostId = nyOmsMASøknad.journalpostId,
+            periode = null,
+            fagsakYtelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_MA
+        )
+        // TODO: Barnet er ikke en del av Midlertidig alene rammevedtak-sakene. Man gjør ingen vurderinger på barnet, vurderer bare om søker er midlertidig alene
+        /*if (nyOmsMASøknad.barn.isNotEmpty()) {
             nyOmsMASøknad.barn.forEach {
                 punsjbolleService.opprettEllerHentFagsaksnummer(
                     søker = nyOmsMASøknad.norskIdent,
@@ -87,7 +95,7 @@ class OmsorgspengerMidlertidigAleneService(
                     fagsakYtelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_MA
                 )
             }
-        }
+        }*/
 
         //setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostRepository.settFagsakYtelseType(

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
@@ -83,19 +83,6 @@ class OmsorgspengerMidlertidigAleneService(
             periode = null,
             fagsakYtelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_MA
         )
-        // TODO: Barnet er ikke en del av Midlertidig alene rammevedtak-sakene. Man gjør ingen vurderinger på barnet, vurderer bare om søker er midlertidig alene
-        /*if (nyOmsMASøknad.barn.isNotEmpty()) {
-            nyOmsMASøknad.barn.forEach {
-                punsjbolleService.opprettEllerHentFagsaksnummer(
-                    søker = nyOmsMASøknad.norskIdent,
-                    annenPart = nyOmsMASøknad.annenPart,
-                    pleietrengende = it.norskIdent,
-                    journalpostId = nyOmsMASøknad.journalpostId,
-                    periode = null,
-                    fagsakYtelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_MA
-                )
-            }
-        }*/
 
         //setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostRepository.settFagsakYtelseType(


### PR DESCRIPTION
Barnet er ikke en del av Midlertidig alene rammevedtak-saken.
Man gjør ingen vurderinger på barnet, vurderer bare om søker er midlertidig alene.