### PR TITLE
Erstatter OMSORGSPENGERUTBETALING med OMSORGSPENGER i fagsakytelsetype.

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
@@ -121,7 +121,7 @@ class MappeService(
         val norskIdent = nySøknad.norskIdent
         val søker = personService.finnEllerOpprettPersonVedNorskIdent(norskIdent)
         val mappeId = mappeRepository.opprettEllerHentMappeForPerson(søker.personId)
-        val bunkeId = bunkeRepository.opprettEllerHentBunkeForFagsakType(mappeId, FagsakYtelseType.OMSORGSPENGERUTBETALING)
+        val bunkeId = bunkeRepository.opprettEllerHentBunkeForFagsakType(mappeId, FagsakYtelseType.OMSORGSPENGER)
 
         val søknadfelles = felles(nySøknad.journalpostId)
         val dto = OmsorgspengerutbetalingSøknadDto(

--- a/app/src/main/kotlin/no/nav/k9punsj/felles/FagsakYtelseType.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/felles/FagsakYtelseType.kt
@@ -7,7 +7,6 @@ enum class FagsakYtelseType(val kode: String, val navn: String, val infotrygdBeh
     OMSORGSPENGER_KRONISK_SYKT_BARN("OMP_KS", "Omsorgspenger kronisk sykt barn", "OM", "OMS"),
     OMSORGSPENGER_MIDLERTIDIG_ALENE("OMP_MA", "Ekstra omsorgsdager midlertidig alene", "OM", "OMS"),
     OMSORGSPENGER_ALENE_OMSORGEN("OMP_AO", "Alene om omsorgen", "OM", "OMS"),
-    OMSORGSPENGERUTBETALING("OMP_UT", "Omsorgspengerutbetaling", "OM", "OMS"),
     UKJENT("UKJENT", "Ukjent", null, null),
     UDEFINERT("-", "Ikke definert", null, null);
 

--- a/app/src/main/kotlin/no/nav/k9punsj/journalpost/PunsjJournalpost.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/journalpost/PunsjJournalpost.kt
@@ -45,11 +45,6 @@ internal fun PunsjJournalpost?.utledeFagsakYtelseType(fagsakYtelseType: FagsakYt
                 logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)
                 type
             }
-            no.nav.k9punsj.felles.FagsakYtelseType.OMSORGSPENGERUTBETALING.kode == this.ytelse -> {
-                val type = FagsakYtelseType.OMSORGSPENGER // TODO: Finnes ikke en for omsorgspengerutbetaling
-                logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)
-                type
-            }
             no.nav.k9punsj.felles.FagsakYtelseType.OMSORGSPENGER_KRONISK_SYKT_BARN.kode == this.ytelse -> {
                 val type = FagsakYtelseType.OMSORGSPENGER_KS
                 logger.info("Utleder fagsakytelsetype fra {} til {}", this.ytelse, type)

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
@@ -50,9 +50,9 @@ data class SvarOmsUtDto(
 )
 
 internal fun Mappe.tilOmsUtVisning(norskIdent: String): SvarOmsUtDto {
-    val bunke = hentFor(FagsakYtelseType.OMSORGSPENGERUTBETALING)
+    val bunke = hentFor(FagsakYtelseType.OMSORGSPENGER)
     if (bunke?.søknader.isNullOrEmpty()) {
-        return SvarOmsUtDto(norskIdent, FagsakYtelseType.OMSORGSPENGERUTBETALING.kode, listOf())
+        return SvarOmsUtDto(norskIdent, FagsakYtelseType.OMSORGSPENGER.kode, listOf())
     }
     val søknader = bunke?.søknader
         ?.filter { s -> !s.sendtInn }
@@ -63,7 +63,7 @@ internal fun Mappe.tilOmsUtVisning(norskIdent: String): SvarOmsUtDto {
                 OmsorgspengerutbetalingSøknadDto(soeknadId = s.søknadId, journalposter = hentUtJournalposter(s))
             }
         }
-    return SvarOmsUtDto(norskIdent, FagsakYtelseType.OMSORGSPENGERUTBETALING.kode, søknader)
+    return SvarOmsUtDto(norskIdent, FagsakYtelseType.OMSORGSPENGER.kode, søknader)
 }
 
 internal fun SøknadEntitet.tilOmsUtvisning(): OmsorgspengerutbetalingSøknadDto {


### PR DESCRIPTION
Det finnes ingen kodeverk for OMP_UT. Bruker derfor OMP.