### PR TITLE
Legger til metadata på søknadsstrukturene.

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgSøknadDto.kt
@@ -24,6 +24,7 @@ data class OmsorgspengerAleneOmsorgSøknadDto(
     val begrunnelseForInnsending: String? = null,
     val harInfoSomIkkeKanPunsjes : Boolean? = null,
     val harMedisinskeOpplysninger : Boolean? = null,
+    val metadata: Map<*, *>? = null
 ) {
     data class BarnDto(
         val norskIdent: String?,

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnSøknadDto.kt
@@ -21,7 +21,8 @@ data class OmsorgspengerKroniskSyktBarnSøknadDto(
     val barn: BarnDto? = null,
     val journalposter: List<String>? = null,
     val harInfoSomIkkeKanPunsjes : Boolean,
-    val harMedisinskeOpplysninger : Boolean
+    val harMedisinskeOpplysninger : Boolean,
+    val metadata: Map<*, *>? = null
 ) {
     data class BarnDto(
         val norskIdent: String?,

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneSøknadDto.kt
@@ -29,7 +29,8 @@ data class OmsorgspengerMidlertidigAleneSøknadDto(
     val annenForelder: AnnenForelder? = null,
     val journalposter: List<String>? = null,
     val harInfoSomIkkeKanPunsjes : Boolean? = null,
-    val harMedisinskeOpplysninger : Boolean? = null
+    val harMedisinskeOpplysninger : Boolean? = null,
+    val metadata: Map<*, *>? = null
 ) {
     data class BarnDto(
         val norskIdent: String?,

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
@@ -29,7 +29,8 @@ data class OmsorgspengerutbetalingSøknadDto(
     val opptjeningAktivitet: ArbeidAktivitetDto? = null,
     val fravaersperioder: List<FraværPeriode>? = null,
     val harInfoSomIkkeKanPunsjes: Boolean? = null,
-    val harMedisinskeOpplysninger: Boolean? = null
+    val harMedisinskeOpplysninger: Boolean? = null,
+    val metadata: Map<*, *>? = null
 ) {
     data class FraværPeriode(
         val aktivitetsFravær: AktivitetFravær,

--- a/app/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseSøknadDto.kt
@@ -32,7 +32,9 @@ data class PleiepengerLivetsSluttfaseSøknadDto(
     val harInfoSomIkkeKanPunsjes : Boolean,
     val harMedisinskeOpplysninger : Boolean,
     val trekkKravPerioder: Set<PeriodeDto> = emptySet(),
-    val begrunnelseForInnsending: BegrunnelseForInnsending? = null) {
+    val begrunnelseForInnsending: BegrunnelseForInnsending? = null,
+    val metadata: Map<*, *>? = null
+) {
 
     data class UttakDto(
         val periode: PeriodeDto?,

--- a/app/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnSøknadDto.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnSøknadDto.kt
@@ -39,7 +39,9 @@ data class PleiepengerSyktBarnSøknadDto(
     val harInfoSomIkkeKanPunsjes : Boolean,
     val harMedisinskeOpplysninger : Boolean,
     val trekkKravPerioder: Set<PeriodeDto> = emptySet(),
-    val begrunnelseForInnsending: BegrunnelseForInnsending? = null) {
+    val begrunnelseForInnsending: BegrunnelseForInnsending? = null,
+    val metadata: Map<*, *>? = null
+) {
 
     data class BarnDto(
         val norskIdent: String?,

--- a/app/src/test/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingDtoRoutesTest.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingDtoRoutesTest.kt
@@ -12,6 +12,7 @@ import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.pleiepengersyktbarn.PleiepengerSyktBarnSøknadDto
 import no.nav.k9punsj.openapi.OasSoknadsfeil
 import no.nav.k9punsj.util.*
+import no.nav.k9punsj.util.TestUtils.hentSøknadId
 import no.nav.k9punsj.util.WebClientUtils.getAndAssert
 import no.nav.k9punsj.util.WebClientUtils.postAndAssert
 import no.nav.k9punsj.util.WebClientUtils.postAndAssertAwaitWithStatusAndBody
@@ -263,12 +264,6 @@ class KorrigeringInntektsmeldingDtoRoutesTest {
     ) {
         søknad.replace("soekerId", norskIdent)
         if (journalpostId != null) søknad.replace("journalposter", arrayOf(journalpostId))
-    }
-
-    private fun hentSøknadId(location: URI?): String? {
-        val path = location?.path
-        val søknadId = path?.substring(path.lastIndexOf('/'))
-        return søknadId?.trim('/')
     }
 
     private fun leggerPåNySøknadId(søknadFraFrontend: MutableMap<String, Any?>, location: URI?) {

--- a/app/src/test/kotlin/no/nav/k9punsj/util/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/util/TestUtils.kt
@@ -1,0 +1,11 @@
+package no.nav.k9punsj.util
+
+import java.net.URI
+
+object TestUtils {
+    fun hentSøknadId(location: URI?): String? {
+        val path = location?.path
+        val søknadId = path?.substring(path.lastIndexOf('/'))
+        return søknadId?.trim('/')
+    }
+}

--- a/app/src/test/resources/omp-ao/søknad-fra-frontend.json
+++ b/app/src/test/resources/omp-ao/søknad-fra-frontend.json
@@ -16,5 +16,9 @@
   },
   "begrunnelseForInnsending": "JEG VET IKKE",
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/omp-ksb/søknad-fra-frontend.json
+++ b/app/src/test/resources/omp-ksb/søknad-fra-frontend.json
@@ -11,5 +11,9 @@
     "123456"
   ],
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": true
+  "harMedisinskeOpplysninger": true,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/omp-ma/søknad-fra-frontend.json
+++ b/app/src/test/resources/omp-ma/søknad-fra-frontend.json
@@ -26,5 +26,9 @@
     }
   },
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/oms-ut/søknad-fra-frontend.json
+++ b/app/src/test/resources/oms-ut/søknad-fra-frontend.json
@@ -67,5 +67,9 @@
     ]
   },
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/oms/søknad-fra-frontend.json
+++ b/app/src/test/resources/oms/søknad-fra-frontend.json
@@ -16,5 +16,9 @@
       "faktiskTidPrDag": null
     }],
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/pls/søknad-fra-frontend.json
+++ b/app/src/test/resources/pls/søknad-fra-frontend.json
@@ -125,5 +125,9 @@
     "harMedsoeker": true
   },
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/psb/ferie-null-søknad.json
+++ b/app/src/test/resources/psb/ferie-null-søknad.json
@@ -54,5 +54,9 @@
     "relasjonTilBarnet": "",
     "beskrivelseAvOmsorgsrollen": ""
   },
-  "bosteder": []
+  "bosteder": [],
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/psb/ferie-søknad.json
+++ b/app/src/test/resources/psb/ferie-søknad.json
@@ -49,5 +49,9 @@
     "relasjonTilBarnet": "",
     "beskrivelseAvOmsorgsrollen": ""
   },
-  "bosteder": []
+  "bosteder": [],
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/psb/søknad-fra-frontend-utlandsoppholdv2.json
+++ b/app/src/test/resources/psb/søknad-fra-frontend-utlandsoppholdv2.json
@@ -187,5 +187,9 @@
     "harMedsoeker": true
   },
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/psb/søknad-fra-frontend.json
+++ b/app/src/test/resources/psb/søknad-fra-frontend.json
@@ -185,5 +185,9 @@
     "harMedsoeker": true
   },
   "harInfoSomIkkeKanPunsjes": true,
-  "harMedisinskeOpplysninger": false
+  "harMedisinskeOpplysninger": false,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }

--- a/app/src/test/resources/psb/søknad-fra-frontend_med_2.json
+++ b/app/src/test/resources/psb/søknad-fra-frontend_med_2.json
@@ -165,5 +165,9 @@
     "harMedsoeker": true
   },
   "harInfoSomIkkeKanPunsjes" : true,
-  "harMedisinskeOpplysninger" : true
+  "harMedisinskeOpplysninger" : true,
+  "metadata": {
+    "radioKnapp_1": true,
+    "radioKnapp_2": false
+  }
 }


### PR DESCRIPTION
Dette er ment å brukes som en mellomlagring av frontendspesifikke verdier som ikke er relevant for selve søknaden i backend.

- Refaktorerer ut hentSøknadId til TestUtils.kt.