### PR TITLE
Legger til funksjonalitet og route for å kunne lukke (ferdigstille) gosysoppgaver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Eksempel: `, assertion=[eyJr...]`
 
 ## Swagger i dev
 Bruk header fra Nav token header i authorize.
-[Swagger](https://k9-punsj.dev.adeo.no/internal/webjars/swagger-ui/index.html?configUrl=/internal/api-docs/swagger-config)
+[Swagger](https://k9-punsj.dev.intern.nav.no/internal/webjars/swagger-ui/index.html?configUrl=/internal/api-docs/swagger-config)
 
 ## Accesstoken i dev
-Husk å være logget inn på [dev](https://k9-punsj.dev.adeo.no/) først, så gå til 
+Husk å være logget inn på [dev](https://k9-punsj.dev.intern.nav.no/) først, så gå til 
 [Nav token header](https://k9-punsj-oidc-auth-proxy.dev.intern.nav.no/api/k9-punsj/oidc/hentNavTokenHeader)
 for å hente token som kan brukes i swagger.
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -195,6 +195,12 @@
             <artifactId>fuel-coroutines</artifactId>
             <version>${fuel.version}</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
+        </dependency>
 
         <!--PDF-->
         <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -195,12 +195,6 @@
             <artifactId>fuel-coroutines</artifactId>
             <version>${fuel.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>4.10.0</version>
-        </dependency>
 
         <!--PDF-->
         <dependency>

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -9,8 +9,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.k9punsj.integrasjoner.gosys.GosysRoutes.Urls.GosysoppgaveIdKey
 import no.nav.k9punsj.openapi.OasFeil
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -64,12 +64,12 @@ internal class GosysOpenApi {
     fun OpprettJournalføringsoppgave(@RequestBody body: GosysRoutes.GosysOpprettJournalføringsOppgaveRequest) {
     }
 
-    @DeleteMapping(GosysRoutes.Urls.FerdigstillGosysoppgave, produces = ["application/json"])
+    @PatchMapping(GosysRoutes.Urls.FerdigstillGosysoppgave, produces = ["application/json"])
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "Oppgave lukket."
+                description = "Oppgave ferdigstilt."
             ),
             ApiResponse(
                 responseCode = "401",
@@ -101,11 +101,11 @@ internal class GosysOpenApi {
         ]
     )
     @Operation(
-        summary = "Lukker gosysoppgave",
-        description = "Lukker gosysoppgave",
+        summary = "Ferdigstiller gosysoppgave",
+        description = "Ferdigstiller gosysoppgave",
         security = [SecurityRequirement(name = "BearerAuth")]
     )
-    fun lukkGosysoppgave(@PathVariable(GosysoppgaveIdKey) gosysoppgaveId: String) {
+    fun ferdigstillGosysoppgave(@PathVariable(GosysoppgaveIdKey) gosysoppgaveId: String) {
     }
 
     @GetMapping(GosysRoutes.Urls.Gjelder, produces = ["application/json"])

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.k9punsj.openapi.OasFeil
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -107,7 +108,7 @@ internal class GosysOpenApi {
         description = "Lukker gosysoppgave",
         security = [SecurityRequirement(name = "BearerAuth")]
     )
-    fun lukkGosysoppgave() {
+    fun lukkGosysoppgave(@PathVariable gosysoppgaveId: String) {
     }
 
     @GetMapping(GosysRoutes.Urls.Gjelder, produces = ["application/json"])

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -63,11 +63,7 @@ internal class GosysOpenApi {
     fun OpprettJournalføringsoppgave(@RequestBody body: GosysRoutes.GosysOpprettJournalføringsOppgaveRequest) {
     }
 
-    @DeleteMapping(
-        GosysRoutes.Urls.LukkGosysoppgave,
-        consumes = ["application/json"],
-        produces = ["application/json"]
-    )
+    @DeleteMapping(GosysRoutes.Urls.LukkGosysoppgave, produces = ["application/json"])
     @ApiResponses(
         value = [
             ApiResponse(

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import no.nav.k9punsj.openapi.OasFeil
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -53,13 +54,60 @@ internal class GosysOpenApi {
             )
         ]
     )
-
     @Operation(
         summary = "Oppretter journalføringsoppgave",
         description = "",
         security = [SecurityRequirement(name = "BearerAuth")]
     )
     fun OpprettJournalføringsoppgave(@RequestBody body: GosysRoutes.GosysOpprettJournalføringsOppgaveRequest) {
+    }
+
+    @DeleteMapping(
+        GosysRoutes.Urls.LukkGosysoppgave,
+        consumes = ["application/json"],
+        produces = ["application/json"]
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Oppgave lukket."
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "Ikke innlogget"
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Ikke tilgang til å lukke gosysoppgaven"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Gosysoppgave eksisterer ikke"
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "Konflikt"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Ukjent feilsituasjon",
+                content = [
+                    Content(
+                        schema = Schema(
+                            implementation = OasFeil::class
+                        )
+                    )
+                ]
+            )
+        ]
+    )
+    @Operation(
+        summary = "Lukker gosysoppgave",
+        description = "Lukker gosysoppgave",
+        security = [SecurityRequirement(name = "BearerAuth")]
+    )
+    fun lukkGosysoppgave() {
     }
 
     @GetMapping(GosysRoutes.Urls.Gjelder, produces = ["application/json"])

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.k9punsj.integrasjoner.gosys.GosysRoutes.Urls.GosysoppgaveIdKey
 import no.nav.k9punsj.openapi.OasFeil
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -104,7 +105,7 @@ internal class GosysOpenApi {
         description = "Lukker gosysoppgave",
         security = [SecurityRequirement(name = "BearerAuth")]
     )
-    fun lukkGosysoppgave(@PathVariable gosysoppgaveId: String) {
+    fun lukkGosysoppgave(@PathVariable(GosysoppgaveIdKey) gosysoppgaveId: String) {
     }
 
     @GetMapping(GosysRoutes.Urls.Gjelder, produces = ["application/json"])

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysOpenApi.kt
@@ -64,7 +64,7 @@ internal class GosysOpenApi {
     fun OpprettJournalføringsoppgave(@RequestBody body: GosysRoutes.GosysOpprettJournalføringsOppgaveRequest) {
     }
 
-    @DeleteMapping(GosysRoutes.Urls.LukkGosysoppgave, produces = ["application/json"])
+    @DeleteMapping(GosysRoutes.Urls.FerdigstillGosysoppgave, produces = ["application/json"])
     @ApiResponses(
         value = [
             ApiResponse(

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -75,11 +75,14 @@ internal class GosysRoutes(
                             .json()
                             .bodyValueAndAwait(OasFeil(feil))
                     }
+                    else {
+                        ServerResponse
+                            .status(HttpStatus.OK)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .buildAndAwait()
+                    }
 
-                    ServerResponse
-                        .status(HttpStatus.OK)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .buildAndAwait()
+
                 } catch (case: IkkeTilgang) {
                     ServerResponse.status(HttpStatus.FORBIDDEN).buildAndAwait()
                 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -5,8 +5,8 @@ import no.nav.k9punsj.PublicRoutes
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.felles.IkkeTilgang
+import no.nav.k9punsj.integrasjoner.gosys.GosysRoutes.Urls.FerdigstillGosysoppgave
 import no.nav.k9punsj.integrasjoner.gosys.GosysRoutes.Urls.GosysoppgaveIdKey
-import no.nav.k9punsj.integrasjoner.gosys.GosysRoutes.Urls.LukkGosysoppgave
 import no.nav.k9punsj.openapi.OasFeil
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import org.slf4j.Logger
@@ -36,7 +36,7 @@ internal class GosysRoutes(
     internal object Urls {
         internal const val OpprettJournalføringsoppgave = "/gosys/opprettJournalforingsoppgave/"
         internal const val GosysoppgaveIdKey = "gosysoppgave_id"
-        internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/{$GosysoppgaveIdKey}"
+        internal const val FerdigstillGosysoppgave = "/gosys/oppgave/ferdigstill/{$GosysoppgaveIdKey}"
 
         internal const val Gjelder = "/gosys/gjelder"
     }
@@ -65,12 +65,12 @@ internal class GosysRoutes(
             }
         }
 
-        PATCH("/api$LukkGosysoppgave") { request ->
+        PATCH("/api$FerdigstillGosysoppgave") { request ->
             RequestContext(coroutineContext, request) {
                 val oppgaveId = request.oppgaveId()
 
-                logger.info("Lukker gosysopgave med id=[{}]", oppgaveId)
-                val (httpStatus, feil) = gosysService.lukkOppgave(oppgaveId = oppgaveId)
+                logger.info("Ferdigstiller gosysopgave med id=[{}]", oppgaveId)
+                val (httpStatus, feil) = gosysService.ferdigstillOppgave(oppgaveId = oppgaveId)
 
                 return@RequestContext if (feil != null) {
                     ServerResponse

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -61,7 +61,7 @@ internal class GosysRoutes(
             }
         }
 
-        DELETE("/api${LukkGosysoppgave}", contentType(MediaType.APPLICATION_JSON)) { request ->
+        DELETE("/api$LukkGosysoppgave", contentType(MediaType.APPLICATION_JSON)) { request ->
             RequestContext(coroutineContext, request) {
                 val oppgaveId = request.oppgaveId()
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -31,7 +31,7 @@ internal class GosysRoutes(
 
     internal object Urls {
         internal const val OpprettJournalføringsoppgave = "/gosys/opprettJournalforingsoppgave/"
-        internal const val GosysoppgaveIdKey = "gosysoppgaveId"
+        internal const val GosysoppgaveIdKey = "gosysoppgave_id"
         internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/{$GosysoppgaveIdKey}"
 
         internal const val Gjelder = "/gosys/gjelder"

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -31,8 +31,8 @@ internal class GosysRoutes(
 
     internal object Urls {
         internal const val OpprettJournalføringsoppgave = "/gosys/opprettJournalforingsoppgave/"
-        internal const val GosysoppgaveIdKey = "{gosysoppgaveId}"
-        internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/$GosysoppgaveIdKey"
+        internal const val GosysoppgaveIdKey = "gosysoppgaveId"
+        internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/{$GosysoppgaveIdKey}"
 
         internal const val Gjelder = "/gosys/gjelder"
     }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -65,7 +65,7 @@ internal class GosysRoutes(
             }
         }
 
-        DELETE("/api$LukkGosysoppgave") { request ->
+        PATCH("/api$LukkGosysoppgave") { request ->
             RequestContext(coroutineContext, request) {
                 val oppgaveId = request.oppgaveId()
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -87,7 +87,7 @@ internal class GosysRoutes(
         }
     }
 
-    private suspend fun ServerRequest.oppgaveId(): String = pathVariable("gosysoppgaveId")
+    private suspend fun ServerRequest.oppgaveId(): String = pathVariable(GosysoppgaveIdKey)
 
     private suspend fun ServerRequest.mapOppgaveRequest() =
         body(BodyExtractors.toMono(GosysOpprettJournalføringsOppgaveRequest::class.java)).awaitFirst()

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -31,10 +31,10 @@ internal class GosysRoutes(
 
     internal object Urls {
         internal const val OpprettJournalføringsoppgave = "/gosys/opprettJournalforingsoppgave/"
-        internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/"
-        internal const val Gjelder = "/gosys/gjelder"
-
         internal const val GosysoppgaveIdKey = "{gosysoppgaveId}"
+        internal const val LukkGosysoppgave = "/gosys/oppgave/lukk/$GosysoppgaveIdKey"
+
+        internal const val Gjelder = "/gosys/gjelder"
     }
 
     @Bean
@@ -61,7 +61,7 @@ internal class GosysRoutes(
             }
         }
 
-        DELETE("/api${LukkGosysoppgave}/$GosysoppgaveIdKey", contentType(MediaType.APPLICATION_JSON)) { request ->
+        DELETE("/api${LukkGosysoppgave}", contentType(MediaType.APPLICATION_JSON)) { request ->
             RequestContext(coroutineContext, request) {
                 val oppgaveId = request.oppgaveId()
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysRoutes.kt
@@ -61,7 +61,7 @@ internal class GosysRoutes(
             }
         }
 
-        DELETE("/api$LukkGosysoppgave", contentType(MediaType.APPLICATION_JSON)) { request ->
+        DELETE("/api$LukkGosysoppgave") { request ->
             RequestContext(coroutineContext, request) {
                 val oppgaveId = request.oppgaveId()
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
@@ -88,9 +88,20 @@ internal class GosysService(
             .buildAndAwait()
     }
 
+    internal suspend fun hentGosysoppgave(oppgaveId: String): Triple<HttpStatus, String?, GetOppgaveResponse?> {
+        return oppgaveGateway.hentOppgave(oppgaveId)
+    }
+
     suspend fun lukkOppgave(oppgaveId: String): Pair<HttpStatus, String?> {
+        val (httpStatus, feil, oppgave) = hentGosysoppgave(oppgaveId)
+        if (!httpStatus.is2xxSuccessful) return httpStatus to feil
+
         return oppgaveGateway.patchOppgave(
-            oppgaveId, PatchOppgaveRequest(id = oppgaveId.toInt(), status = OppgaveStatus.FERDIGSTILT)
+            oppgaveId, PatchOppgaveRequest(
+                id = oppgaveId.toInt(),
+                oppgave!!.versjon,
+                status = OppgaveStatus.FERDIGSTILT
+            )
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
@@ -90,7 +90,7 @@ internal class GosysService(
 
     suspend fun lukkOppgave(oppgaveId: String): Pair<HttpStatus, String?> {
         return oppgaveGateway.patchOppgave(
-            oppgaveId, PatchOppgaveRequest(status = OppgaveStatus.FERDIGSTILT)
+            oppgaveId, PatchOppgaveRequest(id = oppgaveId.toInt(), status = OppgaveStatus.FERDIGSTILT)
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
@@ -89,6 +89,7 @@ internal class GosysService(
     }
 
     internal suspend fun hentGosysoppgave(oppgaveId: String): Triple<HttpStatus, String?, GetOppgaveResponse?> {
+        logger.info("Henter eksisterende gosysoppgave med id=[{}]", oppgaveId)
         return oppgaveGateway.hentOppgave(oppgaveId)
     }
 
@@ -96,6 +97,7 @@ internal class GosysService(
         val (httpStatus, feil, oppgave) = hentGosysoppgave(oppgaveId)
         if (!httpStatus.is2xxSuccessful) return httpStatus to feil
 
+        logger.info("Lukker gosysoppgave med id=[{}]", oppgaveId)
         return oppgaveGateway.patchOppgave(
             oppgaveId, PatchOppgaveRequest(
                 id = oppgaveId.toInt(),

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
@@ -87,4 +87,10 @@ internal class GosysService(
             .contentType(MediaType.APPLICATION_JSON)
             .buildAndAwait()
     }
+
+    suspend fun lukkOppgave(oppgaveId: String): Pair<HttpStatus, String?> {
+        return oppgaveGateway.patchOppgave(
+            oppgaveId, PatchOppgaveRequest(status = OppgaveStatus.FERDIGSTILT)
+        )
+    }
 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/GosysService.kt
@@ -93,11 +93,10 @@ internal class GosysService(
         return oppgaveGateway.hentOppgave(oppgaveId)
     }
 
-    suspend fun lukkOppgave(oppgaveId: String): Pair<HttpStatus, String?> {
+    suspend fun ferdigstillOppgave(oppgaveId: String): Pair<HttpStatus, String?> {
         val (httpStatus, feil, oppgave) = hentGosysoppgave(oppgaveId)
         if (!httpStatus.is2xxSuccessful) return httpStatus to feil
 
-        logger.info("Lukker gosysoppgave med id=[{}]", oppgaveId)
         return oppgaveGateway.patchOppgave(
             oppgaveId, PatchOppgaveRequest(
                 id = oppgaveId.toInt(),

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -118,7 +118,7 @@ internal class OppgaveGateway(
         return httpStatus to if (harFeil) "Feil ved endring av gosysoppgave. Url=[$url], HttpStatus=[$httpStatus], Response=$responseBody" else null
     }
 
-    private suspend fun httpPost(body: String, url: String): Triple<String, ResponseEntity<String>, String> {
+    private suspend fun httpPost(body: String, url: String): Triple<String, ResponseEntity<String>, String?> {
         val responseEntity = client
             .post()
             .uri(url)
@@ -152,7 +152,7 @@ internal class OppgaveGateway(
         return responseEntity.resolve(url)
     }
 
-    private suspend fun httpPatch(body: String, url: String): Triple<String, ResponseEntity<String>, String> {
+    private suspend fun httpPatch(body: String, url: String): Triple<String, ResponseEntity<String>, String?> {
         val responseEntity = client
             .patch()
             .uri(url)
@@ -170,7 +170,7 @@ internal class OppgaveGateway(
         return responseEntity.resolve(url)
     }
 
-    private fun ResponseEntity<String>.resolve(url: String): Triple<String, ResponseEntity<String>, String> = when {
+    private fun ResponseEntity<String>.resolve(url: String): Triple<String, ResponseEntity<String>, String?> = when {
         !statusCode.is2xxSuccessful -> {
             when {
                 body.isNullOrBlank() -> {
@@ -182,7 +182,7 @@ internal class OppgaveGateway(
             }
         }
         else -> {
-            Triple(url, this, body!!)
+            Triple(url, this, body)
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -87,8 +87,6 @@ internal class OppgaveGateway(
                 throw it
             }
 
-        logger.info("PATCH oppgave payload={}", body)
-
         val (url, response, responseBody) = httpPatch(body, "$patchEksisterendeOppgaveUrl/$oppgaveId")
 
         val harFeil = !response.isSuccessful
@@ -124,7 +122,7 @@ internal class OppgaveGateway(
     }
 
     private suspend fun httpPatch(body: String, url: String): Triple<String, Response, String> {
-        val (_, response, result) = "$oppgaveBaseUrl$url"
+        val requestBuilder = "$oppgaveBaseUrl$url"
             .httpPatch()
             .body(body)
             .header(
@@ -134,7 +132,11 @@ internal class OppgaveGateway(
                 NavHeaders.CallId to UUID.randomUUID().toString(),
                 CorrelationIdHeader to coroutineContext.hentCorrelationId(),
                 ConsumerIdHeaderKey to ConsumerIdHeaderValue
-            ).awaitStringResponseResult()
+            )
+
+        logger.info("RequestBuilder: {}", requestBuilder.toString())
+
+        val (_, response, result) = requestBuilder.awaitStringResponseResult()
 
         val responseBody = result.fold(
             { success -> success },

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -135,18 +135,7 @@ internal class OppgaveGateway(
                 .retrieve()
                 .toEntity(String::class.java)
                 .awaitFirst()
-        }.fold(
-            onSuccess = { responseEntity: ResponseEntity<String> -> responseEntity },
-            onFailure = { throwable: Throwable ->
-                when (throwable) {
-                    is WebClientResponseException -> ResponseEntity
-                        .status(throwable.statusCode)
-                        .body(throwable.responseBodyAsString)
-
-                    else -> throw throwable
-                }
-            }
-        )
+        }.håndterFeil()
 
         return responseEntity.resolve(url)
     }
@@ -164,18 +153,7 @@ internal class OppgaveGateway(
                 .retrieve()
                 .toEntity(String::class.java)
                 .awaitFirst()
-        }.fold(
-            onSuccess = { responseEntity: ResponseEntity<String> -> responseEntity },
-            onFailure = { throwable: Throwable ->
-                when (throwable) {
-                    is WebClientResponseException -> ResponseEntity
-                        .status(throwable.statusCode)
-                        .body(throwable.responseBodyAsString)
-
-                    else -> throw throwable
-                }
-            }
-        )
+        }.håndterFeil()
 
         return responseEntity.resolve(url)
     }
@@ -195,21 +173,23 @@ internal class OppgaveGateway(
                 .retrieve()
                 .toEntity<String>()
                 .awaitFirst()
-        }.fold(
-            onSuccess = { responseEntity: ResponseEntity<String> -> responseEntity },
-            onFailure = { throwable: Throwable ->
-                when (throwable) {
-                    is WebClientResponseException -> ResponseEntity
-                        .status(throwable.statusCode)
-                        .body(throwable.responseBodyAsString)
-
-                    else -> throw throwable
-                }
-            }
-        )
+        }.håndterFeil()
 
         return responseEntity.resolve(url)
     }
+
+    private fun Result<ResponseEntity<String>>.håndterFeil() = fold(
+        onSuccess = { responseEntity: ResponseEntity<String> -> responseEntity },
+        onFailure = { throwable: Throwable ->
+            when (throwable) {
+                is WebClientResponseException -> ResponseEntity
+                    .status(throwable.statusCode)
+                    .body(throwable.responseBodyAsString)
+
+                else -> throw throwable
+            }
+        }
+    )
 
     private fun ResponseEntity<String>.resolve(url: String): Triple<String, ResponseEntity<String>, String?> = when {
         !statusCode.is2xxSuccessful -> {

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -87,7 +87,7 @@ internal class OppgaveGateway(
                 throw it
             }
 
-        val (url, response, responseBody) = httpPatch(body, patchEksisterendeOppgaveUrl)
+        val (url, response, responseBody) = httpPatch(body, "$patchEksisterendeOppgaveUrl/$oppgaveId")
 
         val harFeil = !response.isSuccessful
         if (harFeil) {

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -143,7 +143,7 @@ internal class OppgaveGateway(
                         .status(throwable.statusCode)
                         .body(throwable.responseBodyAsString)
 
-                    else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+                    else -> throw throwable
                 }
             }
         )
@@ -172,7 +172,7 @@ internal class OppgaveGateway(
                         .status(throwable.statusCode)
                         .body(throwable.responseBodyAsString)
 
-                    else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+                    else -> throw throwable
                 }
             }
         )
@@ -203,7 +203,7 @@ internal class OppgaveGateway(
                         .status(throwable.statusCode)
                         .body(throwable.responseBodyAsString)
 
-                    else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+                    else -> throw throwable
                 }
             }
         )

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -87,6 +87,8 @@ internal class OppgaveGateway(
                 throw it
             }
 
+        logger.info("PATCH oppgave payload={}", body)
+
         val (url, response, responseBody) = httpPatch(body, "$patchEksisterendeOppgaveUrl/$oppgaveId")
 
         val harFeil = !response.isSuccessful

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OppgaveGateway.kt
@@ -141,11 +141,11 @@ internal class OppgaveGateway(
             .build()
 
         return okHttp.newCall(request).execute().use { response: okhttp3.Response ->
+            val responseBody = response.body
             when {
                 !response.isSuccessful -> {
-                    val responseBody = response.body
-                    when {
-                        responseBody == null || responseBody.string().isBlank() -> {
+                    when (responseBody) {
+                        null -> {
                             Triple(url, response, "{}")
                         }
                         else -> {
@@ -154,7 +154,7 @@ internal class OppgaveGateway(
                     }
                 }
                 else -> {
-                    Triple(url, response, response.body!!.string())
+                    Triple(url, response, responseBody!!.string())
                 }
             }
         }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
@@ -34,3 +34,11 @@ internal data class OpprettOppgaveRequest(
         }
     }
 }
+
+internal data class PatchOppgaveRequest(
+    val status: OppgaveStatus
+)
+
+internal enum class OppgaveStatus {
+    OPPRETTET, AAPNET, UNDER_BEHANDLING, FERDIGSTILT, FEILREGISTRERT
+}

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
@@ -37,6 +37,13 @@ internal data class OpprettOppgaveRequest(
 
 internal data class PatchOppgaveRequest(
     val id: Int,
+    val versjon: Int,
+    val status: OppgaveStatus
+)
+
+internal data class GetOppgaveResponse(
+    val id: Int,
+    val versjon: Int,
     val status: OppgaveStatus
 )
 

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/gosys/OpprettOppgaveRequest.kt
@@ -36,6 +36,7 @@ internal data class OpprettOppgaveRequest(
 }
 
 internal data class PatchOppgaveRequest(
+    val id: Int,
     val status: OppgaveStatus
 )
 

--- a/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
@@ -245,13 +245,6 @@ internal class JournalpostRoutes(
                         .notFound()
                         .buildAndAwait())
 
-                val gosysoppgaveId = journalpost.gosysoppgaveId
-                if (!gosysoppgaveId.isNullOrBlank()) {
-                    val (httpStatus, feil) = gosysService.lukkOppgave(gosysoppgaveId)
-                    if (!httpStatus.is2xxSuccessful) return@RequestContext ServerResponse
-                        .status(httpStatus.value())
-                        .bodyValueAndAwait(feil!!)
-                }
 
                 aksjonspunktService.settUtførtPåAltSendLukkOppgaveTilK9Los(journalpostId, false, null)
                 journalpostService.settTilFerdig(journalpostId)

--- a/nais/dev-fss.yml
+++ b/nais/dev-fss.yml
@@ -57,7 +57,7 @@ spec:
     pool: nav-dev
   env:
     - name: SWAGGER_SERVER_BASE_URL
-      value: https://k9-punsj.dev.adeo.no
+      value: https://k9-punsj.dev.intern.nav.no
     - name: NAIS_STS_TOKEN_ENDPOINT
       value: https://security-token-service.nais.preprod.local/rest/v1/sts/token
     - name: SAF_BASE_URL


### PR DESCRIPTION
For å kunne endre en eksisterende oppgave trenger man å sette en versjon-id for å unngå konflikt når flere behandler oppgaven. Vi henter da eksisterende oppgave, og bruker gjeldende versjon-id når vi setter gosysoppgaven til `FERDIGSTILT`.

Erstatter Fuel med Spring WebClient i OppgaveGateway.