### PR TITLE
Utvider matchfagsak-kontrakt

### DIFF
--- a/app/src/main/kotlin/no/nav/k9punsj/felles/dto/FellesDtoer.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/felles/dto/FellesDtoer.kt
@@ -37,7 +37,8 @@ data class SendSøknad(
 
 data class Matchfagsak(
     val brukerIdent: String,
-    val barnIdent: String? = null
+    val barnIdent: String? = null,
+    val periode: PeriodeDto? = null
 )
 
 data class MatchFagsakMedPeriode(

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -6,9 +6,24 @@ import no.nav.k9punsj.felles.dto.PeriodeDto
 
 interface K9SakService {
 
-    suspend fun hentPerioderSomFinnesIK9(søker: String, barn: String? = null, fagsakYtelseType: FagsakYtelseType): Pair<List<PeriodeDto>?, String?>
+    suspend fun hentPerioderSomFinnesIK9(
+        søker: String,
+        barn: String? = null,
+        fagsakYtelseType: FagsakYtelseType
+    ): Pair<List<PeriodeDto>?, String?>
 
-    suspend fun hentArbeidsforholdIdFraInntektsmeldinger(søker: String, fagsakYtelseType: FagsakYtelseType, periodeDto: PeriodeDto): Pair<List<ArbeidsgiverMedArbeidsforholdId>?, String?>
+    suspend fun hentPerioderSomFinnesIK9ForPeriode(
+        søker: String,
+        barn: String? = null,
+        fagsakYtelseType: FagsakYtelseType,
+        periode: PeriodeDto
+    ): Pair<List<PeriodeDto>?, String?>
+
+    suspend fun hentArbeidsforholdIdFraInntektsmeldinger(
+        søker: String,
+        fagsakYtelseType: FagsakYtelseType,
+        periodeDto: PeriodeDto
+    ): Pair<List<ArbeidsgiverMedArbeidsforholdId>?, String?>
 
     suspend fun hentFagsaker(søker: String): Pair<Set<Fagsak>?, String?>
 }

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -13,6 +13,7 @@ import no.nav.k9punsj.felles.NavHeaders
 import no.nav.k9punsj.felles.dto.ArbeidsgiverMedArbeidsforholdId
 import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.hentCallId
+import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.finnFagsak
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentIntektsmelidnger
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentPerioder
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.sokFagsaker
@@ -45,6 +46,8 @@ class K9SakServiceImpl(
         internal const val hentPerioder = "/behandling/soknad/perioder"
         internal const val hentIntektsmelidnger = "/behandling/iay/im-arbeidsforhold-v2"
         internal const val sokFagsaker = "/fagsak/sok"
+        internal const val finnFagsak = "/fordel/fagsak/sok"
+        internal const val hentPerioderForSaksnummer = "/behandling/soknad/perioder/saksnummer"
     }
 
     override suspend fun hentPerioderSomFinnesIK9(
@@ -75,12 +78,46 @@ class K9SakServiceImpl(
         }
     }
 
+    override suspend fun hentPerioderSomFinnesIK9ForPeriode(
+        søker: String,
+        barn: String?,
+        fagsakYtelseType: no.nav.k9punsj.felles.FagsakYtelseType,
+        periode: PeriodeDto
+    ): Pair<List<PeriodeDto>?, String?> {
+        val matchMedPeriodeDto = MatchMedPeriodeDto(
+            ytelseType = FagsakYtelseType.fraKode(fagsakYtelseType.kode),
+            bruker = søker,
+            pleietrengende = barn,
+            periode = periode
+        )
+
+        val saksnummerBody = kotlin.runCatching { objectMapper().writeValueAsString(matchMedPeriodeDto) }.getOrNull()
+            ?: return Pair(null, "Feilet serialisering")
+
+        val (saksnummerJson, saksnummerFeil) = httpPost(saksnummerBody, finnFagsak)
+        saksnummerFeil?.let { Pair(null, saksnummerFeil) }
+        val saksnummer = saksnummerJson ?: return Pair(null, "Fant ikke saksnummer")
+
+        val (json, feil) = httpPost(saksnummer, hentPerioder)
+        return try {
+            if (json == null) {
+                return Pair(null, feil!!)
+            }
+            val resultat = objectMapper().readValue<List<Periode>>(json)
+            val liste = resultat
+                .map { periode -> PeriodeDto(periode.fom, periode.tom) }.toList()
+            Pair(liste, null)
+        } catch (e: Exception) {
+            Pair(null, "Feilet deserialisering $e")
+        }
+    }
+
     override suspend fun hentArbeidsforholdIdFraInntektsmeldinger(
         søker: String,
         fagsakYtelseType: no.nav.k9punsj.felles.FagsakYtelseType,
         periodeDto: PeriodeDto,
     ): Pair<List<ArbeidsgiverMedArbeidsforholdId>?, String?> {
-        val matchDto = MatchMedPeriodeDto(
+        val matchDto = MatchArbeidsforholdDto(
             ytelseType = FagsakYtelseType.fraKode(fagsakYtelseType.kode),
             bruker = søker,
             periode = periodeDto
@@ -205,6 +242,13 @@ class K9SakServiceImpl(
         )
 
         data class MatchMedPeriodeDto(
+            val ytelseType: FagsakYtelseType,
+            val bruker: String,
+            val pleietrengende: String? = null,
+            val periode: PeriodeDto
+        )
+
+        data class MatchArbeidsforholdDto(
             val ytelseType: FagsakYtelseType,
             val bruker: String,
             val periode: PeriodeDto,

--- a/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -16,6 +16,7 @@ import no.nav.k9punsj.hentCallId
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.finnFagsak
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentIntektsmelidnger
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentPerioder
+import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentPerioderForSaksnummer
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.sokFagsaker
 import no.nav.k9punsj.utils.objectMapper
 import org.intellij.lang.annotations.Language
@@ -78,6 +79,10 @@ class K9SakServiceImpl(
         }
     }
 
+    /*
+     * 1. Slår opp saksnummer basert på ytelsetype, periode & søkers aktørId.
+     * 2. Henter perioder for saksnummer.
+     */
     override suspend fun hentPerioderSomFinnesIK9ForPeriode(
         søker: String,
         barn: String?,
@@ -98,7 +103,7 @@ class K9SakServiceImpl(
         saksnummerFeil?.let { Pair(null, saksnummerFeil) }
         val saksnummer = saksnummerJson ?: return Pair(null, "Fant ikke saksnummer")
 
-        val (json, feil) = httpPost(saksnummer, hentPerioder)
+        val (json, feil) = httpPost(saksnummer, hentPerioderForSaksnummer)
         return try {
             if (json == null) {
                 return Pair(null, feil!!)

--- a/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingService.kt
+++ b/app/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingService.kt
@@ -284,10 +284,18 @@ internal class OmsorgspengerutbetalingService(
     }
 
     internal suspend fun hentInfoFraK9Sak(matchfagsak: Matchfagsak): List<PeriodeDto> {
-        val (perioder, _) = k9SakService.hentPerioderSomFinnesIK9(
-            søker = matchfagsak.brukerIdent,
-            fagsakYtelseType = FagsakYtelseType.OMSORGSPENGER
-        )
+        val (perioder, _) = if(matchfagsak.periode == null) {
+            k9SakService.hentPerioderSomFinnesIK9(
+                søker = matchfagsak.brukerIdent,
+                fagsakYtelseType = FagsakYtelseType.OMSORGSPENGER
+            )
+        } else {
+            k9SakService.hentPerioderSomFinnesIK9ForPeriode(
+                søker = matchfagsak.brukerIdent,
+                fagsakYtelseType = FagsakYtelseType.OMSORGSPENGER,
+                periode = matchfagsak.periode
+            )
+        }
 
         return perioder ?: listOf()
     }

--- a/app/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -29,6 +29,15 @@ class LokalK9SakService : K9SakService {
         false -> Pair(emptyList(), null)
     }
 
+    override suspend fun hentPerioderSomFinnesIK9ForPeriode(
+        søker: String,
+        barn: String?,
+        fagsakYtelseType: FagsakYtelseType,
+        periode: PeriodeDto
+    ): Pair<List<PeriodeDto>?, String?> {
+        return hentPerioderSomFinnesIK9(søker = søker, barn = barn, fagsakYtelseType = fagsakYtelseType)
+    }
+
     override suspend fun hentArbeidsforholdIdFraInntektsmeldinger(
         søker: String,
         fagsakYtelseType: FagsakYtelseType,

--- a/app/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/app/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -18,6 +18,15 @@ internal class TestK9SakService : K9SakService {
         fagsakYtelseType: FagsakYtelseType
     ): Pair<List<PeriodeDto>?, String?> = Pair(emptyList(), null)
 
+    override suspend fun hentPerioderSomFinnesIK9ForPeriode(
+        søker: String,
+        barn: String?,
+        fagsakYtelseType: FagsakYtelseType,
+        periode: PeriodeDto
+    ): Pair<List<PeriodeDto>?, String?> {
+        return hentPerioderSomFinnesIK9(søker = søker, barn = barn, fagsakYtelseType = fagsakYtelseType)
+    }
+
     override suspend fun hentArbeidsforholdIdFraInntektsmeldinger(
         søker: String,
         fagsakYtelseType: FagsakYtelseType,


### PR DESCRIPTION
Gør det mulig o sende in periode når vi henter perioder for en fagsak så att vi kan punsje omsorgspenger søknader fra tidigare år. Pr nå henter vi siste fagsak, så om det finns fagsak for 2023 kan vi ikke punsje søknader fra 2022 lenger.