### PR TITLE
Korrigering av k9 saksnummer håndtering

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
@@ -442,6 +442,7 @@ internal class MappeService(
         return Mappe(mappeId, søker, bunkerMedSøknader)
     }
 
+    @Deprecated("Bruk soknadService")
     suspend fun hentSøknad(søknad: String): SøknadEntitet? {
         return soknadService.hentSøknad(søknad)
     }

--- a/src/main/kotlin/no/nav/k9punsj/domenetjenester/SoknadService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/domenetjenester/SoknadService.kt
@@ -109,13 +109,6 @@ class SoknadService(
             }
             fagsakIder.first().second
         } else {
-            // Hent k9saksnummer
-            val k9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-                søknadstype = fagsakYtelseType,
-                søker = søkerFnr,
-                pleietrengende = søknad.berørtePersoner?.firstOrNull()?.personIdent?.verdi,
-                annenPart = søknad.berørtePersoner?.firstOrNull()?.personIdent?.verdi
-            )
             val k9Respons = k9SakService.hentEllerOpprettSaksnummer(søknad.søknadId.toString())
             require(k9Respons.second.isNullOrBlank()) { "Feil ved henting av saksnummer: ${k9Respons.second}" }
             logger.info("Fick saksnummer (${k9Respons.second} av K9Sak for Journalpost ${journalpostIder.first()}")

--- a/src/main/kotlin/no/nav/k9punsj/domenetjenester/SoknadService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/domenetjenester/SoknadService.kt
@@ -6,7 +6,9 @@ import no.nav.k9.kodeverk.Fagsystem
 import no.nav.k9.kodeverk.dokument.Brevkode
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9.søknad.Søknad
+import no.nav.k9punsj.domenetjenester.repository.BunkeRepository
 import no.nav.k9punsj.domenetjenester.repository.SøknadRepository
+import no.nav.k9punsj.felles.FagsakYtelseType
 import no.nav.k9punsj.felles.Identitetsnummer.Companion.somIdentitetsnummer
 import no.nav.k9punsj.felles.JournalpostId.Companion.somJournalpostId
 import no.nav.k9punsj.felles.Søknadstype
@@ -39,7 +41,7 @@ import java.util.UUID
 import kotlin.coroutines.coroutineContext
 
 @Service
-internal class SoknadService(
+class SoknadService(
     private val journalpostService: JournalpostService,
     private val søknadRepository: SøknadRepository,
     private val søknadMetrikkService: SøknadMetrikkService,
@@ -47,7 +49,8 @@ internal class SoknadService(
     private val k9SakService: K9SakService,
     private val sakClient: SakClient,
     private val pdlService: PdlService,
-    private val dokarkivGateway: DokarkivGateway
+    private val dokarkivGateway: DokarkivGateway,
+    private val bunkeRepository: BunkeRepository
 ) {
 
     internal suspend fun sendSøknad(
@@ -59,7 +62,7 @@ internal class SoknadService(
 
         val journalpostIdListe = journalpostIder.toList()
         val journalposterKanSendesInn = journalpostService.kanSendeInn(journalpostIdListe)
-        val punsjetAvSaksbehandler = søknadRepository.hentSøknad(søknad.søknadId.id)?.endret_av!!.replace("\"", "")
+        val punsjetAvSaksbehandler = hentSistEndretAvSaksbehandler(søknad.søknadId.id)
 
         val søkerFnr = søknad.søker.personIdent.verdi
         val k9YtelseType = Søknadstype.fraBrevkode(brevkode).k9YtelseType
@@ -111,10 +114,9 @@ internal class SoknadService(
                 søknadstype = fagsakYtelseType,
                 søker = søkerFnr,
                 pleietrengende = søknad.berørtePersoner?.firstOrNull()?.personIdent?.verdi,
-                annenPart = søknad.berørtePersoner?.firstOrNull()?.personIdent?.verdi,
-                journalpostId = journalpostIder.first() // TODO: Brukes for å utlede dato, hentes fra behandlingsAar.
+                annenPart = søknad.berørtePersoner?.firstOrNull()?.personIdent?.verdi
             )
-            val k9Respons = k9SakService.hentEllerOpprettSaksnummer(k9SaksnummerGrunnlag)
+            val k9Respons = k9SakService.hentEllerOpprettSaksnummer(søknad.søknadId.toString())
             require(k9Respons.second.isNullOrBlank()) { "Feil ved henting av saksnummer: ${k9Respons.second}" }
             logger.info("Fick saksnummer (${k9Respons.second} av K9Sak for Journalpost ${journalpostIder.first()}")
             k9Respons.first
@@ -238,6 +240,12 @@ internal class SoknadService(
 
     suspend fun hentSistEndretAvSaksbehandler(søknadId: String): String {
         return søknadRepository.hentSøknad(søknadId)?.endret_av!!.replace("\"", "")
+    }
+
+    suspend fun henteYtelsetypeForSøknad(søknadId: String): FagsakYtelseType? {
+        return hentSøknad(søknadId)?.bunkeId?.let { bunkeId ->
+            bunkeRepository.hentYtelseTypeForBunke(bunkeId)
+        }
     }
 
     private suspend fun leggerVedPayload(

--- a/src/main/kotlin/no/nav/k9punsj/domenetjenester/repository/BunkeRepository.kt
+++ b/src/main/kotlin/no/nav/k9punsj/domenetjenester/repository/BunkeRepository.kt
@@ -72,4 +72,23 @@ class BunkeRepository(private val dataSource: DataSource) {
             }
         }
     }
+
+    suspend fun hentYtelseTypeForBunke(bunkeId: String): FagsakYtelseType? {
+        return using(sessionOf(dataSource)) {
+            return@using it.transaction { tx ->
+                return@transaction tx.run(
+                    queryOf(
+                        """
+                                select ytelse_type from $BUNKE_TABLE where bunke_id = :bunkeId
+                             """,
+                        mapOf(
+                            "bunkeId" to UUID.fromString(bunkeId)
+                        )
+                    ).map { row ->
+                        FagsakYtelseType.fromKode(row.string("ytelse_type"))
+                    }.asSingle
+                )
+            }
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafGateway.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafGateway.kt
@@ -94,17 +94,21 @@ class SafGateway(
             UUID.randomUUID().toString()
         }
 
-        val response = client
-            .post()
-            .uri { it.pathSegment("graphql").build() }
-            .header(ConsumerIdHeaderKey, ConsumerIdHeaderValue)
-            .header(CorrelationIdHeader, correlationId)
-            .header(HttpHeaders.AUTHORIZATION, accessToken.asAuthoriationHeader())
-            .accept(MediaType.APPLICATION_JSON)
-            .bodyValue(SafDtos.JournalpostQuery(journalpostId))
-            .retrieve()
-            .toEntity(SafDtos.JournalpostResponseWrapper::class.java)
-            .awaitFirst()
+        val response = try {
+            client
+                .post()
+                .uri { it.pathSegment("graphql").build() }
+                .header(ConsumerIdHeaderKey, ConsumerIdHeaderValue)
+                .header(CorrelationIdHeader, correlationId)
+                .header(HttpHeaders.AUTHORIZATION, accessToken.asAuthoriationHeader())
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(SafDtos.JournalpostQuery(journalpostId))
+                .retrieve()
+                .toEntity(SafDtos.JournalpostResponseWrapper::class.java)
+                .awaitFirst()
+        } catch (e: Exception) {
+            throw IllegalStateException("Feil ved oppslag mot SAF graphql. ${e.message}", e)
+        }
 
         val safResponse = response.body
         val errors = safResponse?.errors

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/HentK9SaksnummerGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/HentK9SaksnummerGrunnlagDto.kt
@@ -1,11 +1,12 @@
 package no.nav.k9punsj.integrasjoner.k9sak
 
 import no.nav.k9punsj.felles.FagsakYtelseType
+import no.nav.k9punsj.felles.dto.PeriodeDto
 
 data class HentK9SaksnummerGrunnlag(
     val søknadstype: FagsakYtelseType,
     val søker: String,
     val pleietrengende: String?,
     val annenPart: String?,
-    val journalpostId: String
+    val periode: PeriodeDto?,
 )

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -32,9 +32,9 @@ interface K9SakService {
 
     /**
      * Henter saksnummer fra K9Sak, hvis det ikke finnes oppretter vi en ny fagsak.
-     * Bruker behandlingsAar fra PunsjJournalpost for å sikkre riktig periode for saksnummeret.
+     * Periode hentes fra soknaden å defaulter til 1/1 og 31/12 hvis fom eller tom ikke er satt.
      */
-    suspend fun hentEllerOpprettSaksnummer(k9SaksnummerGrunnlag: HentK9SaksnummerGrunnlag): Pair<String?, String?>
+    suspend fun hentEllerOpprettSaksnummer(søknadId: String): Pair<String?, String?>
 
     suspend fun hentSisteSaksnummerForPeriode(
         fagsakYtelseType: FagsakYtelseType,

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/sak/SakClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/sak/SakClient.kt
@@ -17,7 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.net.URI
 
 @Service
-internal class SakClient(
+class SakClient(
     @Value("\${no.nav.sak.base_url}") private val baseUrl: URI,
     @Qualifier("sts") private val accessTokenClient: AccessTokenClient,
 ) {

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostService.kt
@@ -50,12 +50,14 @@ class JournalpostService(
     internal suspend fun hentSafJournalPost(journalpostId: String): SafDtos.Journalpost? =
         safGateway.hentJournalpostInfo(journalpostId)
 
+    @Deprecated("Periode skal hentes fra søknaden i soknadservice. FIXME")
     internal suspend fun hentBehandlingsAar(journalpostId: String): Int {
         val behandlingsAar = journalpostRepository.hent(journalpostId).behandlingsAar
         logger.info("Hentet behandlingsår ($behandlingsAar) for journalpost: $journalpostId")
         return behandlingsAar ?: LocalDate.now().year
     }
 
+    @Deprecated("Periode skal hentes fra søknaden i soknadservice. FIXME")
     internal suspend fun lagreBehandlingsAar(journalpostId: String, behandlingsAar: Int) {
         val journalpost = journalpostRepository.hentHvis(journalpostId)
         if (journalpost != null) {
@@ -105,6 +107,7 @@ class JournalpostService(
         }
     }
 
+    @Deprecated("Kan sende in betyr att den har blitt sendt in fra før? FIXME")
     internal fun kanSendesInn(søknadEntitet: SøknadEntitet): MutableSet<String> {
         val journalPoster = søknadEntitet.journalposter!!
         val journalposterDto: JournalposterDto = objectMapper.convertValue(journalPoster)
@@ -200,6 +203,7 @@ class JournalpostService(
         return journalpostRepository.hentHvis(journalpostId)
     }
 
+    @Deprecated("Kan sende in betyr att den har blitt sendt in fra før? FIXME")
     internal suspend fun kanSendeInn(journalpostId: List<String>): Boolean {
         return journalpostRepository.kanSendeInn(journalpostId)
     }

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/dto/SkalTilInfotrygdSvar.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/dto/SkalTilInfotrygdSvar.kt
@@ -1,3 +1,4 @@
 package no.nav.k9punsj.journalpost.dto
 
+@Deprecated("Skal ikke brukes, sjekk om den er i bruk o før du sletter")
 data class SkalTilInfotrygdSvar(val k9sak: Boolean)

--- a/src/main/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingRoutes.kt
@@ -109,6 +109,7 @@ internal class KorrigeringInntektsmeldingRoutes(
             }
         }
 
+        // TODO: Denne skal ikke vara i en søknadstype, flytte till k9-sak route el. liknande
         POST("/api${Urls.HentArbeidsforholdIderFraK9sak}") { request ->
             RequestContext(coroutineContext, request) {
                 val matchfagsakMedPeriode = request.mapMatchFagsakMedPerioder()

--- a/src/main/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingService.kt
@@ -18,7 +18,6 @@ import no.nav.k9punsj.felles.dto.OpprettNySøknad
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.omsorgspengerutbetaling.SvarOmsUtDto
@@ -82,26 +81,6 @@ internal class KorrigeringInntektsmeldingService(
     }
 
     internal suspend fun nySøknad(request: ServerRequest, opprettNySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.OMSORGSPENGER,
-            annenPart = opprettNySøknad.annenPart,
-            søker = opprettNySøknad.norskIdent,
-            pleietrengende = opprettNySøknad.pleietrengendeIdent,
-            journalpostId = opprettNySøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(FagsakYtelseType.OMSORGSPENGER, opprettNySøknad.journalpostId)
 
@@ -248,6 +227,7 @@ internal class KorrigeringInntektsmeldingService(
             .bodyValueAndAwait(søknad)
     }
 
+    @Deprecated("Skall flyttes til felles k9sak-route")
     internal suspend fun hentArbeidsforholdIderFraK9Sak(matchFagsakMedPeriode: MatchFagsakMedPeriode): ServerResponse {
         val (arbeidsgiverMedArbeidsforholdId, feil) = k9SakService.hentArbeidsforholdIdFraInntektsmeldinger(
             søker = matchFagsakMedPeriode.brukerIdent,

--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgService.kt
@@ -15,8 +15,6 @@ import no.nav.k9punsj.felles.dto.OpprettNySøknad
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
-import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.tilgangskontroll.azuregraph.IAzureGraphService
 import no.nav.k9punsj.utils.ServerRequestUtils.søknadLocationUri
@@ -37,7 +35,6 @@ internal class OmsorgspengerAleneOmsorgService(
     private val azureGraphService: IAzureGraphService,
     private val journalpostService: JournalpostService,
     private val soknadService: SoknadService,
-    private val k9SakService: K9SakService,
     private val aksjonspunktService: AksjonspunktService
 ) {
 
@@ -76,26 +73,6 @@ internal class OmsorgspengerAleneOmsorgService(
     }
 
     suspend fun nySøknad(request: ServerRequest, opprettNySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.OMSORGSPENGER_ALENE_OMSORGEN,
-            annenPart = opprettNySøknad.annenPart,
-            søker = opprettNySøknad.norskIdent,
-            pleietrengende = opprettNySøknad.pleietrengendeIdent,
-            journalpostId = opprettNySøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             ytelseType = FagsakYtelseType.OMSORGSPENGER_ALENE_OMSORGEN,

--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnService.kt
@@ -15,8 +15,6 @@ import no.nav.k9punsj.felles.dto.OpprettNySøknad
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
-import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
 import no.nav.k9punsj.tilgangskontroll.azuregraph.IAzureGraphService
@@ -38,7 +36,6 @@ internal class OmsorgspengerKroniskSyktBarnService(
     private val journalpostService: JournalpostService,
     private val azureGraphService: IAzureGraphService,
     private val soknadService: SoknadService,
-    private val k9SakService: K9SakService,
     private val aksjonspunktService: AksjonspunktService
 ) {
 
@@ -79,26 +76,6 @@ internal class OmsorgspengerKroniskSyktBarnService(
     }
 
     suspend fun nySøknad(request: ServerRequest, nySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.OMSORGSPENGER_KRONISK_SYKT_BARN,
-            annenPart = nySøknad.annenPart,
-            søker = nySøknad.norskIdent,
-            pleietrengende = nySøknad.pleietrengendeIdent,
-            journalpostId = nySøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             ytelseType = FagsakYtelseType.OMSORGSPENGER_KRONISK_SYKT_BARN,

--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneService.kt
@@ -14,8 +14,6 @@ import no.nav.k9punsj.felles.dto.JournalposterDto
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
-import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
 import no.nav.k9punsj.tilgangskontroll.azuregraph.IAzureGraphService
@@ -37,7 +35,6 @@ internal class OmsorgspengerMidlertidigAleneService(
     private val azureGraphService: IAzureGraphService,
     private val soknadService: SoknadService,
     private val objectMapper: ObjectMapper,
-    private val k9SakService: K9SakService,
     private val aksjonspunktService: AksjonspunktService
 ) {
 
@@ -79,26 +76,6 @@ internal class OmsorgspengerMidlertidigAleneService(
     }
 
     internal suspend fun nySøknad(request: ServerRequest, nyOmsMASøknad: NyOmsMASøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.OMSORGSPENGER_MIDLERTIDIG_ALENE,
-            annenPart = nyOmsMASøknad.annenPart,
-            søker = nyOmsMASøknad.norskIdent,
-            pleietrengende = null,
-            journalpostId = nyOmsMASøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             ytelseType = FagsakYtelseType.OMSORGSPENGER_MIDLERTIDIG_ALENE,

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -17,7 +17,6 @@ import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
@@ -40,8 +39,8 @@ internal class OpplaeringspengerService(
     private val azureGraphService: IAzureGraphService,
     private val objectMapper: ObjectMapper,
     private val soknadService: SoknadService,
-    private val k9SakService: K9SakService,
-    private val aksjonspunktService: AksjonspunktService
+    private val aksjonspunktService: AksjonspunktService,
+    private val k9SakService: K9SakService
 ) {
 
     private companion object {
@@ -183,26 +182,6 @@ internal class OpplaeringspengerService(
     }
 
     internal suspend fun nySøknad(request: ServerRequest, nySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.OPPLÆRINGSPENGER,
-            annenPart = nySøknad.annenPart,
-            søker = nySøknad.norskIdent,
-            pleietrengende = nySøknad.pleietrengendeIdent,
-            journalpostId = nySøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             FagsakYtelseType.OPPLÆRINGSPENGER,
@@ -272,6 +251,7 @@ internal class OpplaeringspengerService(
             .bodyValueAndAwait(søknad)
     }
 
+    @Deprecated("Flyttes til felles k9-sak tjeneste")
     internal suspend fun hentInfoFraK9Sak(matchfagsak: Matchfagsak): ServerResponse {
         val (perioder, _) = k9SakService.hentPerioderSomFinnesIK9(
             matchfagsak.brukerIdent,

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseService.kt
@@ -17,7 +17,6 @@ import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
@@ -40,8 +39,8 @@ internal class PleiepengerLivetsSluttfaseService(
     private val azureGraphService: IAzureGraphService,
     private val journalpostService: JournalpostService,
     private val soknadService: SoknadService,
-    private val k9SakService: K9SakService,
-    private val aksjonspunktService: AksjonspunktService
+    private val aksjonspunktService: AksjonspunktService,
+    private val k9SakService: K9SakService
 ) {
 
     private companion object {
@@ -178,28 +177,6 @@ internal class PleiepengerLivetsSluttfaseService(
     }
 
     internal suspend fun nySøknad(request: ServerRequest, opprettNySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        if (opprettNySøknad.pleietrengendeIdent != null) {
-            val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-                søknadstype = FagsakYtelseType.PLEIEPENGER_LIVETS_SLUTTFASE,
-                annenPart = null,
-                søker = opprettNySøknad.norskIdent,
-                pleietrengende = opprettNySøknad.pleietrengendeIdent,
-                journalpostId = opprettNySøknad.journalpostId
-            )
-
-            val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-                k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-            )
-
-            if(feil != null) {
-                return ServerResponse
-                    .badRequest()
-                    .json()
-                    .bodyValueAndAwait(feil)
-            }
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             FagsakYtelseType.PLEIEPENGER_LIVETS_SLUTTFASE,
@@ -268,6 +245,7 @@ internal class PleiepengerLivetsSluttfaseService(
             .bodyValueAndAwait(søknad)
     }
 
+    @Deprecated("Flyttes til felles k9-sak tjeneste")
     internal suspend fun hentInfoFraK9Sak(matchfagsak: Matchfagsak): ServerResponse {
         val (perioder, _) = k9SakService.hentPerioderSomFinnesIK9(
             søker = matchfagsak.brukerIdent,
@@ -288,6 +266,7 @@ internal class PleiepengerLivetsSluttfaseService(
         }
     }
 
+    @Deprecated("Flyttes til felles k9-sak tjeneste")
     private suspend fun henterPerioderSomFinnesIK9sak(dto: PleiepengerLivetsSluttfaseSøknadDto): Pair<List<PeriodeDto>?, String?>? {
         if (dto.soekerId.isNullOrBlank() || dto.pleietrengende == null || dto.pleietrengende.norskIdent.isNullOrBlank()) {
             return null

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
@@ -17,7 +17,6 @@ import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.felles.dto.SendSøknad
 import no.nav.k9punsj.felles.dto.SøknadFeil
 import no.nav.k9punsj.felles.dto.hentUtJournalposter
-import no.nav.k9punsj.integrasjoner.k9sak.HentK9SaksnummerGrunnlag
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
@@ -183,26 +182,6 @@ internal class PleiepengerSyktBarnService(
     }
 
     internal suspend fun nySøknad(request: ServerRequest, nySøknad: OpprettNySøknad): ServerResponse {
-        // oppretter sak i k9-sak hvis det ikke finnes fra før
-        val hentK9SaksnummerGrunnlag = HentK9SaksnummerGrunnlag(
-            søknadstype = FagsakYtelseType.PLEIEPENGER_SYKT_BARN,
-            annenPart = nySøknad.annenPart,
-            søker = nySøknad.norskIdent,
-            pleietrengende = nySøknad.pleietrengendeIdent,
-            journalpostId = nySøknad.journalpostId
-        )
-
-        val (_, feil) = k9SakService.hentEllerOpprettSaksnummer(
-            k9SaksnummerGrunnlag = hentK9SaksnummerGrunnlag
-        )
-
-        if (feil != null) {
-            return ServerResponse
-                .badRequest()
-                .json()
-                .bodyValueAndAwait(feil)
-        }
-
         // setter riktig type der man jobber på en ukjent i utgangspunktet
         journalpostService.settFagsakYtelseType(
             ytelseType = FagsakYtelseType.PLEIEPENGER_SYKT_BARN,
@@ -270,6 +249,7 @@ internal class PleiepengerSyktBarnService(
             .bodyValueAndAwait(søknad)
     }
 
+    @Deprecated("Flyttes til felles k9-sak tjeneste")
     internal suspend fun hentInfoFraK9Sak(matchfagsak: Matchfagsak): ServerResponse {
         val (perioder, _) = k9SakService.hentPerioderSomFinnesIK9(
             matchfagsak.brukerIdent,
@@ -290,6 +270,7 @@ internal class PleiepengerSyktBarnService(
         }
     }
 
+    @Deprecated("Flyttes til felles k9-sak tjeneste")
     private suspend fun henterPerioderSomFinnesIK9sak(dto: PleiepengerSyktBarnSøknadDto): Pair<List<PeriodeDto>?, String?>? {
         if (dto.soekerId.isNullOrBlank() || dto.barn == null || dto.barn.norskIdent.isNullOrBlank()) {
             return null

--- a/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
@@ -14,7 +14,9 @@ import no.nav.k9.søknad.ytelse.Ytelse
 import no.nav.k9.søknad.ytelse.Ytelse.PLEIEPENGER_SYKT_BARN
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
 import no.nav.k9punsj.akjonspunkter.AksjonspunktService
+import no.nav.k9punsj.domenetjenester.repository.BunkeRepository
 import no.nav.k9punsj.domenetjenester.repository.SøknadRepository
+import no.nav.k9punsj.felles.FagsakYtelseType
 import no.nav.k9punsj.felles.Identitetsnummer.Companion.somIdentitetsnummer
 import no.nav.k9punsj.felles.JournalpostId.Companion.somJournalpostId
 import no.nav.k9punsj.felles.dto.SøknadEntitet
@@ -77,6 +79,9 @@ internal class SoknadServiceTest {
 
     private lateinit var soknadService: SoknadService
 
+    @MockK
+    private lateinit var bunkeRepository: BunkeRepository
+
     @BeforeAll
     fun setup() {
         MockKAnnotations.init(this)
@@ -90,6 +95,7 @@ internal class SoknadServiceTest {
             )
         )
         coEvery { mockJournalpostService.hent(any()) }.returns(PunsjJournalpost(UUID.randomUUID(), "1", aktørId = "1"))
+        coEvery { bunkeRepository.hentYtelseTypeForBunke(any()) }.returns(FagsakYtelseType.OMSORGSPENGER)
         soknadService = SoknadService(
             journalpostService = mockJournalpostService,
             søknadRepository = mockSøknadRepository,
@@ -98,7 +104,8 @@ internal class SoknadServiceTest {
             k9SakService = k9SakService,
             sakClient = sakClient,
             pdlService = pdlService,
-            dokarkivGateway = dokarkivGateway
+            dokarkivGateway = dokarkivGateway,
+            bunkeRepository = bunkeRepository,
         )
     }
 

--- a/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
@@ -176,7 +176,7 @@ internal class SoknadServiceTest {
                 sak = FerdigstillJournalpost.Sak(null, null, null)
             )
         )
-        coEvery { k9SakService.hentEllerOpprettSaksnummer(any()) }.returns(Pair("ABC123", null))
+        //coEvery { k9SakService.hentEllerOpprettSaksnummer(any()) }.returns(Pair("ABC123", null))
         coEvery { pdlService.hentPersonopplysninger(any()) }.returns(
             setOf(
                 Personopplysninger(

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -72,9 +72,7 @@ class LokalK9SakService : K9SakService {
         second = null
     )
 
-    override suspend fun hentEllerOpprettSaksnummer(
-        k9SaksnummerGrunnlag: HentK9SaksnummerGrunnlag
-    ): Pair<String?, String?> {
+    override suspend fun hentEllerOpprettSaksnummer(søknadId: String): Pair<String?, String?> {
         return Pair("ABC123", null)
     }
 

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -86,9 +86,7 @@ internal class TestK9SakService : K9SakService {
         second = null
     )
 
-    override suspend fun hentEllerOpprettSaksnummer(
-        k9SaksnummerGrunnlag: HentK9SaksnummerGrunnlag
-    ): Pair<String?, String?> {
+    override suspend fun hentEllerOpprettSaksnummer(søknadId: String): Pair<String?, String?> {
         return Pair("ABC123", null)
     }
 


### PR DESCRIPTION
Oppretter ikke nytt saksnr når man starter ny søknad.
Saksnummer fra k9 hentes fra SAF når vi sender in søknad. 
Finner vi ikke saksnummer så kaller vi /fordel/fagsak/opprett med data fra punsj søknaden.