### PR TITLE
Setter ikke avsenderMottakerNavn dersom avsenderMottakerId finnes.

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGateway.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGateway.kt
@@ -248,7 +248,11 @@ class DokarkivGateway(
     ) =
         getJSONObject("journalpost")
             .let { journalpost ->
-                val avsendernavn = journalpost.getJSONObject("avsenderMottaker").stringOrNull("navn")
+                val avsenderMottaker = journalpost.getJSONObject("avsenderMottaker")
+                val avsenderIdType = avsenderMottaker.stringOrNull("idType")
+                val avsenderId = if (avsenderIdType == "FNR") avsenderMottaker.stringOrNull("id") else null
+                val avsendernavn = if (avsenderId.isNullOrBlank()) avsenderMottaker.stringOrNull("navn") else null
+
                 val journalpostStatus = journalpost.getString("journalstatus").somJournalpostStatus()
                 val journalpostType = journalpost.getString("journalposttype").somJournalpostType()
                 val tittel = journalpost.stringOrNull("tittel")
@@ -263,6 +267,7 @@ class DokarkivGateway(
                 FerdigstillJournalpost(
                     journalpostId = journalpostId,
                     avsendernavn = avsendernavn,
+                    avsenderId = avsenderId,
                     status = journalpostStatus,
                     type = journalpostType,
                     tittel = tittel,

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/FerdigstillJournalpost.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/FerdigstillJournalpost.kt
@@ -14,6 +14,7 @@ internal data class FerdigstillJournalpost(
     private val status: JoarkTyper.JournalpostStatus,
     private val type: JoarkTyper.JournalpostType,
     private val avsendernavn: String? = null,
+    private val avsenderId: String? = null,
     private val tittel: String? = null,
     private val dokumenter: Set<Dokument> = emptySet(),
     private val bruker: Bruker? = null,
@@ -70,8 +71,9 @@ internal data class FerdigstillJournalpost(
             }
             json.put("dokumenter", jsonDokumenter)
         }
-        // Mangler navn på avsender
-        if (avsendernavn.isNullOrBlank() && !type.erNotat) {
+
+        // Hvis avsenderId er satt, så skal ikke avsendernavn være satt
+        if (avsenderId.isNullOrBlank() && avsendernavn.isNullOrBlank() && !type.erNotat) {
             json.put("avsenderMottaker", JSONObject().also { it.put("navn", bruker.navn!!) })
             utfyllendeInformasjon.add("avsenderMottaker.navn=[***]")
         }

--- a/src/test/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGatewayTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGatewayTest.kt
@@ -6,6 +6,7 @@ import no.nav.k9punsj.felles.Identitetsnummer.Companion.somIdentitetsnummer
 import no.nav.k9punsj.felles.JournalpostId.Companion.somJournalpostId
 import no.nav.k9punsj.integrasjoner.dokarkiv.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
 import no.nav.k9punsj.integrasjoner.dokarkiv.JoarkTyper.JournalpostType.Companion.somJournalpostType
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -15,22 +16,57 @@ class DokarkivGatewayTest {
     fun `Oppdaterer journalpost med utfyllende info for ferdigstilling`() {
         val saksnummer = Saksnummer("1DP1GG8")
         val journalpost = FerdigstillJournalpost(
-            journalpostId="598146191".somJournalpostId(),
-            status="MOTTATT".somJournalpostStatus(),
-            type="I".somJournalpostType(),
-            avsendernavn="Pessimistisk, Bildekort",
-            tittel="Søknad om utbetaling av omsorgspenger for arbeidstaker",
-            dokumenter=setOf(FerdigstillJournalpost.Dokument(dokumentId="624895411", tittel="Søknad om utbetaling av omsorgspenger for arbeidstaker")),
-            bruker= FerdigstillJournalpost.Bruker(
+            journalpostId = "598146191".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            type = "I".somJournalpostType(),
+            avsendernavn = "Pessimistisk, Bildekort",
+            tittel = "Søknad om utbetaling av omsorgspenger for arbeidstaker",
+            dokumenter = setOf(
+                FerdigstillJournalpost.Dokument(
+                    dokumentId = "624895411",
+                    tittel = "Søknad om utbetaling av omsorgspenger for arbeidstaker"
+                )
+            ),
+            bruker = FerdigstillJournalpost.Bruker(
                 identitetsnummer = "15069205221".somIdentitetsnummer(),
                 sak = Pair(Fagsystem.K9SAK, saksnummer),
-                navn="Pessimistisk Bildekort"
+                navn = "Pessimistisk Bildekort"
             ),
-        sak= FerdigstillJournalpost.Sak(sakstype = "FAGSAK", fagsaksystem = "K9", fagsakId = saksnummer.toString())
+            sak = FerdigstillJournalpost.Sak(sakstype = "FAGSAK", fagsaksystem = "K9", fagsakId = saksnummer.toString())
         )
 
         val oppdatertJournalpost = journalpost.oppdaterPayloadMedSak()
 
         assertNotEquals(journalpost, oppdatertJournalpost)
+    }
+
+    @Test
+    fun `Oppdaterert journalpost skal ikke oppdatere avsendernavn dersom avsenderid er satt`() {
+        val saksnummer = Saksnummer("1DP1GG8")
+        val journalpost = FerdigstillJournalpost(
+            journalpostId = "598146191".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            type = "I".somJournalpostType(),
+            avsenderId = "15069205221",
+            avsendernavn = "En eller annen avsender",
+            tittel = "Søknad om utbetaling av omsorgspenger for arbeidstaker",
+            dokumenter = setOf(
+                FerdigstillJournalpost.Dokument(
+                    dokumentId = "624895411",
+                    tittel = "Søknad om utbetaling av omsorgspenger for arbeidstaker"
+                )
+            ),
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = "15069205221".somIdentitetsnummer(),
+                sak = Pair(Fagsystem.K9SAK, saksnummer),
+                navn = "Pessimistisk Bildekort"
+            ),
+            sak = FerdigstillJournalpost.Sak(sakstype = "FAGSAK", fagsaksystem = "K9", fagsakId = saksnummer.toString())
+        )
+
+        val oppdatertJournalpost = journalpost.oppdaterPayloadMedSak()
+
+        assertNotEquals(journalpost, oppdatertJournalpost)
+        Assertions.assertThat(oppdatertJournalpost).doesNotContain("En eller annen avsender")
     }
 }


### PR DESCRIPTION
Det er ikke nødvendig å oppgi navn når idType=FNR. Dokarkiv vil da hente personens navn fra PDL.