### PR TITLE
Fikser henting av avsluttede arbeidsforhold.

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
@@ -58,9 +58,7 @@ internal class AaregClient(
             "Uventet response fra Aareg. HttpStatus=${response.statusCode}, Response=$responseBody fra Url=$url"
         }
 
-        val deserialiser = responseBody.deserialiser<List<AaregArbeidsforhold>>()
-        logger.info("Hentet ${deserialiser.size} arbeidsforhold fra Aareg")
-        val organisasjoner = deserialiser
+        val organisasjoner = responseBody.deserialiser<List<AaregArbeidsforhold>>()
             .filter { arbeidsforhold -> arbeidsforhold.arbeidssted.identer.any { it.type == AaregIdentType.ORGANISASJONSNUMMER } }
             .filter { it.ansettelsesperiode.harArbeidsforholdIPerioden(fom, tom) }
             .map {
@@ -71,7 +69,7 @@ internal class AaregClient(
             }
             .toSet()
 
-        logger.info("Hentet ${organisasjoner.size} arbeidsgivere etter filtrering fra Aareg")
+        logger.info("Hentet ${organisasjoner.size} arbeidsgivere fra Aareg etter filtrering")
         return Arbeidsforhold(
             organisasjoner = organisasjoner
         )

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
@@ -58,7 +58,9 @@ internal class AaregClient(
             "Uventet response fra Aareg. HttpStatus=${response.statusCode}, Response=$responseBody fra Url=$url"
         }
 
-        val organisasjoner = responseBody.deserialiser<List<AaregArbeidsforhold>>()
+        val aaregArbeidsforhold = responseBody.deserialiser<List<AaregArbeidsforhold>>()
+        logger.info("Hentet ${aaregArbeidsforhold.size} arbeidsforhold fra Aareg")
+        val organisasjoner = aaregArbeidsforhold
             .filter { arbeidsforhold -> arbeidsforhold.arbeidssted.identer.any { it.type == AaregIdentType.ORGANISASJONSNUMMER } }
             .filter { it.ansettelsesperiode.harArbeidsforholdIPerioden(fom, tom) }
             .map {

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
@@ -69,7 +69,7 @@ internal class AaregClient(
             }
             .toSet()
 
-        logger.info("Hentet ${organisasjoner.size} arbeidsgivere fra Aareg etter filtrering")
+        logger.info("Returnerer ${organisasjoner.size} arbeidsgivere filtrering")
         return Arbeidsforhold(
             organisasjoner = organisasjoner
         )

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/AaregClient.kt
@@ -66,7 +66,8 @@ internal class AaregClient(
             .map {
                 OrganisasjonArbeidsforhold(
                     organisasjonsnummer = it.arbeidssted.identer.first().ident,
-                    arbeidsforholdId = it.id
+                    arbeidsforholdId = it.id,
+                    erAvsluttet = it.ansettelsesperiode.sluttdato != null
                 )
             }
             .toSet()

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/Arbeidsforhold.kt
@@ -6,5 +6,6 @@ internal data class Arbeidsforhold(
 
 internal data class OrganisasjonArbeidsforhold(
     val arbeidsforholdId: String?,
-    val organisasjonsnummer: String
+    val organisasjonsnummer: String,
+    val erAvsluttet: Boolean = false
 )

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgiverService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgiverService.kt
@@ -102,7 +102,8 @@ internal class ArbeidsgiverService(
             organisasjoner = arbeidsforhold.organisasjoner.distinctBy { it.organisasjonsnummer }.map {
                 OrganisasjonArbeidsgiver(
                     organisasjonsnummer = it.organisasjonsnummer,
-                    navn = hentOrganisasjonsnavn(it.organisasjonsnummer) ?: "Ikke tilgjengelig"
+                    navn = hentOrganisasjonsnavn(it.organisasjonsnummer) ?: "Ikke tilgjengelig",
+                    erAvsluttet = it.erAvsluttet
                 )
             }.toSet()
         )

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgiverService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgiverService.kt
@@ -2,6 +2,7 @@ package no.nav.k9punsj.integrasjoner.arbeidsgivere
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.LocalDate
@@ -11,6 +12,9 @@ internal class ArbeidsgiverService(
     private val aaregClient: AaregClient,
     private val eregClient: EregClient
 ) {
+    private companion object {
+        private val logger = LoggerFactory.getLogger(ArbeidsgiverService::class.java)
+    }
 
     private val arbeidsgivereCache: Cache<Triple<String, LocalDate, LocalDate>, Arbeidsgivere> = Caffeine.newBuilder()
         .expireAfterWrite(Duration.ofMinutes(10))
@@ -32,33 +36,23 @@ internal class ArbeidsgiverService(
         identitetsnummer: String,
         fom: LocalDate,
         tom: LocalDate,
-        historikk: Boolean = false
+        inkluderAvsluttetArbeidsforhold: Boolean = false
     ): Arbeidsgivere {
         val cacheKey = Triple(identitetsnummer, fom, tom)
-
+        logger.info("Henter arbeidsgivere, fom=$fom, tom=$tom, inkluderAvsluttetArbeidsforhold=$inkluderAvsluttetArbeidsforhold")
         return when (val cacheValue = arbeidsgivereCache.getIfPresent(cacheKey)) {
-            null -> slåOppArbeidsgivere(
-                identitetsnummer = identitetsnummer,
-                fom = fom,
-                tom = tom,
-                historikk = historikk
-            ).also { arbeidsgivereCache.put(cacheKey, it) }
+            null -> {
+                slåOppArbeidsgivere(
+                    identitetsnummer = identitetsnummer,
+                    fom = fom,
+                    tom = tom,
+                    inkluderAvsluttetArbeidsforhold = inkluderAvsluttetArbeidsforhold
+                ).also { arbeidsgivereCache.put(cacheKey, it) }
+            }
             else -> cacheValue
+        }.also {
+            logger.info("Hentet ${it.organisasjoner.size} arbeidsgivere.")
         }
-    }
-
-    internal suspend fun hentArbeidsgivereHistorikk(
-        identitetsnummer: String,
-        fom: LocalDate,
-        tom: LocalDate,
-        historikk: Boolean
-    ): Arbeidsgivere {
-        return slåOppArbeidsgivere(
-            identitetsnummer = identitetsnummer,
-            fom = fom,
-            tom = tom,
-            historikk = historikk
-        )
     }
 
     internal suspend fun hentArbeidsgivereMedId(
@@ -95,13 +89,13 @@ internal class ArbeidsgiverService(
         identitetsnummer: String,
         fom: LocalDate,
         tom: LocalDate,
-        historikk: Boolean
+        inkluderAvsluttetArbeidsforhold: Boolean
     ): Arbeidsgivere {
         val arbeidsforhold = aaregClient.hentArbeidsforhold(
             identitetsnummer = identitetsnummer,
             fom = fom,
             tom = tom,
-            historikk = historikk
+            inkluderAvsluttetArbeidsforhold = inkluderAvsluttetArbeidsforhold
         )
 
         return Arbeidsgivere(

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/Arbeidsgivere.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/Arbeidsgivere.kt
@@ -6,5 +6,6 @@ internal data class Arbeidsgivere(
 
 internal data class OrganisasjonArbeidsgiver(
     val organisasjonsnummer: String,
-    val navn: String
+    val navn: String,
+    val erAvsluttet: Boolean
 )

--- a/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
@@ -15,7 +15,8 @@ internal class ArbeidsgivereRoutesTest : AbstractContainerBaseTest() {
             {
               "organisasjoner": [{
                 "organisasjonsnummer": "979312059",
-                "navn": "NAV AS"
+                "navn": "NAV AS",
+                "erAvsluttet": false
               }]
             }
         """.trimIndent()
@@ -74,15 +75,18 @@ internal class ArbeidsgivereRoutesTest : AbstractContainerBaseTest() {
               "organisasjoner": [
                   {
                     "organisasjonsnummer": "27500",
-                    "navn": "QuakeWorld AS"
+                    "navn": "QuakeWorld AS",
+                    "erAvsluttet": false
                   },
                   {
                     "organisasjonsnummer": "27015",
-                    "navn": "CounterStrike AS"
+                    "navn": "CounterStrike AS",
+                    "erAvsluttet": true
                   },
                   {
                     "organisasjonsnummer": "5001",
-                    "navn": "Ultima Online AS"
+                    "navn": "Ultima Online AS",
+                    "erAvsluttet": true
                   },
               ]
             }

--- a/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
@@ -90,7 +90,7 @@ internal class ArbeidsgivereRoutesTest : AbstractContainerBaseTest() {
 
         webTestClient.get()
             .uri {
-                it.path("/api/arbeidsgivere-historikk").queryParam("historikk", "true").build()
+                it.path("/api/arbeidsgivere").queryParam("inkluderAvsluttetArbeidsforhold", "true").build()
             }
             .accept(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)


### PR DESCRIPTION
- Utvider endepunktet for henting arbeidsgivere med query parameter `inkluderAvsluttetArbeidsforhold` for å kunne hente avsluttede arbeidsforhold.
- Legger på felt `erAvsluttet` som indikerer om arbeidsforholdet er avsluttet.
- Legger på bedre logging.
- Tilpasser tester etter endring.

[AAREG Swagger doc (krever naisdevice)](https://aareg-services-q1.dev.intern.nav.no/swagger-ui/index.html?urls.primaryName=aareg.api.v2#/arbeidstaker/finnArbeidsforholdPrArbeidstaker)