### PR TITLE
Håndterer journalposter som ikke er tema OMS.

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafDtos.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafDtos.kt
@@ -175,6 +175,7 @@ internal object SafDtos {
             true -> !(erEttersendelse || erSøknad)
             false -> false
         }
+        val ikkeErTemaOMS = tema?.let { Tema.OMS.name != it } ?: false
     }
 
     internal data class Tilleggsopplysning(

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafGateway.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/SafGateway.kt
@@ -152,6 +152,11 @@ class SafGateway(
             logger.warn("Ikke støttet journalstatus ${journalpost?.journalstatus}.")
         }
 
+
+        if (journalpost != null && journalpost.ikkeErTemaOMS) throw IkkeStøttetJournalpost().also {
+            logger.warn("Ikke støttet journalpost ${journalpost.journalstatus}. Tema er ikke lenger OMS, men ${journalpost.tema}.")
+        }
+
         // Kan ikke oppdatere eller ferdigstille Notater som er under redigering.
         if (journalpost?.journalposttype == "N" &&
             journalpost.journalstatus?.equals("UNDER_ARBEID") == true

--- a/src/test/kotlin/no/nav/k9punsj/journalpost/SafDtosTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/journalpost/SafDtosTest.kt
@@ -27,6 +27,26 @@ internal class SafDtosTest {
     }
 
     @Test
+    internal fun skal_sjekke_erIkkeStøttetTema_true() {
+        val journalpost = SafDtos.Journalpost(
+            journalpostId = "123456789",
+            tema = "AAP",
+            tittel = "Arbeidsavklaringspenger",
+            journalposttype = SafDtos.JournalpostType.I.name,
+            journalstatus = SafDtos.Journalstatus.MOTTATT.name,
+            bruker = null,
+            sak = null,
+            avsender = null,
+            avsenderMottaker = null,
+            dokumenter = emptyList(),
+            relevanteDatoer = emptyList(),
+            tilleggsopplysninger = listOf()
+        )
+
+        Assertions.assertThat(journalpost.ikkeErTemaOMS).isTrue()
+    }
+
+    @Test
     internal fun skal_sjekke_erIkkeStøttetDigitalJournalpost_true() {
         val journalpost = SafDtos.Journalpost(
             journalpostId = "123456789",


### PR DESCRIPTION
Kaster `IkkeStøttetJournalpost`, dersom journalpostens tema ikke er OMS. 
Temaet kan endre seg etter at journalposten har kommet inn til punsj, og feiler ved oppslag fordi den ikke støttes.

Når denne feilen forekommer, vil det tillate saksbehandler å kunne lukke journalføringsoppgaven i LOS.