### PR TITLE
TSFF-659: Mulighet for å også oppgi desimaltall for omsorgstilbud

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/MapPsbTilK9Format.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/MapPsbTilK9Format.kt
@@ -255,13 +255,7 @@ internal class MapPsbTilK9Format(
         filter { it.periode.erSatt() }.forEach { tilsynsordning ->
             val k9Periode = tilsynsordning.periode!!.somK9Periode()!!
             k9Tilsynsordning[k9Periode] = TilsynPeriodeInfo()
-                .medEtablertTilsynTimerPerDag(
-                    Duration
-                        .ofHours(tilsynsordning.timer.toLong())
-                        .plusMinutes(
-                            tilsynsordning.minutter.toLong()
-                        )
-                )
+                .medEtablertTilsynTimerPerDag(tilsynsordning.duration)
         }
         if (k9Tilsynsordning.isNotEmpty()) {
             pleiepengerSyktBarn.medTilsynsordning(Tilsynsordning().medPerioder(k9Tilsynsordning))

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSøknadVisningDtoUtils.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSøknadVisningDtoUtils.kt
@@ -144,7 +144,7 @@ internal object PleiepengerSøknadVisningDtoUtils {
         ),
         tilsynsordning = PleiepengerSyktBarnSøknadDto.TilsynsordningDto(
             perioder = listOf(
-                PleiepengerSyktBarnSøknadDto.TilsynsordningInfoDto(
+                PleiepengerSyktBarnSøknadDto.TilsynsordningInfoDto.LegacyTilsynsordningInfoDto(
                     periode = optionalPeriode,
                     timer = 0,
                     minutter = 0

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengersyktbarnTests.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengersyktbarnTests.kt
@@ -8,6 +8,7 @@ import no.nav.k9.søknad.felles.type.Periode
 import no.nav.k9.søknad.ytelse.psb.v1.Omsorg
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn
 import no.nav.k9punsj.AbstractContainerBaseTest
+import no.nav.k9punsj.felles.DurationMapper.somTimerOgMinutter
 import no.nav.k9punsj.felles.dto.OpprettNySøknad
 import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.felles.dto.SendSøknad
@@ -523,8 +524,8 @@ class PleiepengersyktbarnTests : AbstractContainerBaseTest() {
                 )
                 assertThat(søknad.beredskap?.first()?.tilleggsinformasjon).isEqualTo("FÅ SLUTT PÅ COVID!!!")
                 assertThat(søknad.nattevaak?.first()?.tilleggsinformasjon).isEqualTo("FÅ SLUTT PÅ COVID!!!")
-                assertThat(søknad.tilsynsordning?.perioder?.first()?.timer).isEqualTo(7)
-                assertThat(søknad.tilsynsordning?.perioder?.first()?.minutter).isEqualTo(30)
+                assertThat(søknad.tilsynsordning?.perioder?.first()?.duration?.somTimerOgMinutter()?.first).isEqualTo(7)
+                assertThat(søknad.tilsynsordning?.perioder?.first()?.duration?.somTimerOgMinutter()?.second).isEqualTo(30)
                 assertThat(søknad.uttak?.first()?.timerPleieAvBarnetPerDag).isEqualTo("7,5")
                 assertThat(søknad.omsorg?.relasjonTilBarnet).isEqualTo("MOR")
                 assertThat(søknad.bosteder!![0].land).isEqualTo("RU")


### PR DESCRIPTION
I tillegg til timer/minutter som finnes fra før. Implementasjonen er bakoverkompatibel (vil fungere uten samtidig endring i frontend)