### PR TITLE
Lag OLP endepunkt for å hente institusjoner fra k9-sak

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -1,6 +1,7 @@
 package no.nav.k9punsj.integrasjoner.k9sak
 
 import no.nav.k9.kodeverk.dokument.Brevkode
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9.søknad.Søknad
 import no.nav.k9punsj.felles.PunsjFagsakYtelseType
@@ -61,4 +62,6 @@ interface K9SakService {
         saksnummer: String,
         brevkode: Brevkode,
     )
+
+    suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?>
 }

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -63,5 +63,5 @@ interface K9SakService {
         brevkode: Brevkode,
     )
 
-    suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?>
+    suspend fun hentInstitusjoner(): List<GodkjentOpplæringsinstitusjonDto>
 }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
@@ -117,14 +117,7 @@ internal class OpplaeringspengerRoutes(
         }
 
         GET("/api${Urls.HentInstitusjoner}") { request ->
-
-            // Usikker på om vi trenger å sjekke tilgang her
             RequestContext(coroutineContext, request) {
-                /*
-                val norskIdent = request.hentNorskIdentHeader()
-                innlogget.harInnloggetBrukerTilgangTilOgSendeInn(norskIdent = norskIdent, url = Urls.HentInstitusjoner)
-                    ?.let { return@RequestContext it }
-*/
                 opplaeringspengerService.hentInstitusjoner()
             }
         }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
@@ -36,6 +36,7 @@ internal class OpplaeringspengerRoutes(
         internal const val SendEksisterendeSøknad = "/$søknadType/send" // post
         internal const val ValiderSøknad = "/$søknadType/valider" // post
         internal const val HentInfoFraK9sak = "/$søknadType/k9sak/info" // post
+        internal const val HentInstitusjoner = "/$søknadType/institusjoner" // get
     }
 
     @Bean
@@ -112,6 +113,19 @@ internal class OpplaeringspengerRoutes(
                 )?.let { return@RequestContext it }
 
                 opplaeringspengerService.hentInfoFraK9Sak(matchfagsak)
+            }
+        }
+
+        GET("/api${Urls.HentInstitusjoner}") { request ->
+
+            // Usikker på om vi trenger å sjekke tilgang her
+            RequestContext(coroutineContext, request) {
+                /*
+                val norskIdent = request.hentNorskIdentHeader()
+                innlogget.harInnloggetBrukerTilgangTilOgSendeInn(norskIdent = norskIdent, url = Urls.HentInstitusjoner)
+                    ?.let { return@RequestContext it }
+*/
+                opplaeringspengerService.hentInstitusjoner()
             }
         }
     }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
@@ -14,6 +14,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyExtractors
 import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.json
 import kotlin.coroutines.coroutineContext
 
 @Configuration
@@ -118,7 +121,12 @@ internal class OpplaeringspengerRoutes(
 
         GET("/api${Urls.HentInstitusjoner}") { request ->
             RequestContext(coroutineContext, request) {
-                opplaeringspengerService.hentInstitusjoner()
+                val institusjoner = opplaeringspengerService.hentInstitusjoner()
+
+                ServerResponse
+                    .ok()
+                    .json()
+                    .bodyValueAndAwait(institusjoner)
             }
         }
     }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -77,18 +77,12 @@ internal class OpplaeringspengerService(
     }
 
     internal suspend fun hentInstitusjoner(): ServerResponse {
-        val (institusjoner, feil) = k9SakService.hentInstitusjoner()
+        val institusjoner = k9SakService.hentInstitusjoner()
 
-        if (feil != null) {
-            return ServerResponse
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .json()
-                .bodyValueAndAwait(OasFeil(feil))
-        }
         return ServerResponse
             .ok()
             .json()
-            .bodyValueAndAwait(institusjoner!!)
+            .bodyValueAndAwait(institusjoner)
     }
 
     internal suspend fun oppdaterEksisterendeSøknad(

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -76,6 +76,14 @@ internal class OpplaeringspengerService(
             .bodyValueAndAwait(søknad.tilOlpvisning())
     }
 
+    internal suspend fun hentInstitusjoner(): ServerResponse {
+        val institusjoner = k9SakService.hentInstitusjoner()
+        return ServerResponse
+            .ok()
+            .json()
+            .bodyValueAndAwait(institusjoner)
+    }
+
     internal suspend fun oppdaterEksisterendeSøknad(
         request: ServerRequest,
         søknad: OpplaeringspengerSøknadDto

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -3,6 +3,7 @@ package no.nav.k9punsj.opplaeringspenger
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
 import no.nav.k9.kodeverk.dokument.Brevkode
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
 import no.nav.k9.søknad.Søknad
 import no.nav.k9.søknad.felles.Feil
 import no.nav.k9punsj.akjonspunkter.AksjonspunktService
@@ -76,13 +77,8 @@ internal class OpplaeringspengerService(
             .bodyValueAndAwait(søknad.tilOlpvisning())
     }
 
-    internal suspend fun hentInstitusjoner(): ServerResponse {
-        val institusjoner = k9SakService.hentInstitusjoner()
-
-        return ServerResponse
-            .ok()
-            .json()
-            .bodyValueAndAwait(institusjoner)
+    internal suspend fun hentInstitusjoner(): List<GodkjentOpplæringsinstitusjonDto> {
+        return k9SakService.hentInstitusjoner()
     }
 
     internal suspend fun oppdaterEksisterendeSøknad(

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -77,11 +77,18 @@ internal class OpplaeringspengerService(
     }
 
     internal suspend fun hentInstitusjoner(): ServerResponse {
-        val institusjoner = k9SakService.hentInstitusjoner()
+        val (institusjoner, feil) = k9SakService.hentInstitusjoner()
+
+        if (feil != null) {
+            return ServerResponse
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .json()
+                .bodyValueAndAwait(OasFeil(feil))
+        }
         return ServerResponse
             .ok()
             .json()
-            .bodyValueAndAwait(institusjoner)
+            .bodyValueAndAwait(institusjoner!!)
     }
 
     internal suspend fun oppdaterEksisterendeSøknad(

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadOpenApi.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadOpenApi.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
 import no.nav.k9punsj.felles.IdentOgJournalpost
 import no.nav.k9punsj.felles.dto.Matchfagsak
 import no.nav.k9punsj.felles.dto.PerioderDto
@@ -271,5 +272,28 @@ internal class OpplaeringspengerSoknadOpenApi {
         ]
     )
     fun HentInfoFraK9sak(@RequestBody matchFagsak: Matchfagsak) {
+    }
+
+    @GetMapping(OpplaeringspengerRoutes.Urls.HentInstitusjoner, produces = ["application/json"])
+    @Operation(
+        summary = "Henter alle godkjente institusjoner.",
+        security = [SecurityRequirement(name = OpenApi.OAUTH2)]
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Henter alle godkjente institusjoner.",
+                content = [
+                    Content(
+                        schema = Schema(
+                            implementation = GodkjentOpplæringsinstitusjonDto::class
+                        )
+                    )
+                ]
+            )
+        ]
+    )
+    private fun HentInstitusjoner() {
     }
 }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadOpenApi.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadOpenApi.kt
@@ -1,6 +1,7 @@
 package no.nav.k9punsj.opplaeringspenger
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -286,8 +287,10 @@ internal class OpplaeringspengerSoknadOpenApi {
                 description = "Henter alle godkjente institusjoner.",
                 content = [
                     Content(
-                        schema = Schema(
-                            implementation = GodkjentOpplæringsinstitusjonDto::class
+                        array = ArraySchema(
+                            schema = Schema(
+                                implementation = GodkjentOpplæringsinstitusjonDto::class
+                            )
                         )
                     )
                 ]

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/HentInstitusjonerTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/HentInstitusjonerTest.kt
@@ -8,13 +8,16 @@ import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.G
 import no.nav.k9.sak.typer.Periode
 import no.nav.k9punsj.AbstractContainerBaseTest
 import no.nav.k9punsj.CALL_ID_KEY
+import no.nav.k9punsj.felles.RestKallException
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
+import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentInstitusjonerUrl
 import no.nav.k9punsj.wiremock.saksbehandlerAccessToken
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import java.net.URI
 import java.time.LocalDate
 import java.util.*
 
@@ -23,6 +26,7 @@ internal class HentInstitusjonerTest : AbstractContainerBaseTest() {
     @MockkBean
     private lateinit var k9SakService: K9SakService
 
+    private val hentInstitusjonerPunsjUrl = "/api/opplaeringspenger-soknad/institusjoner"
     private val saksbehandlerAuthorizationHeader = "Bearer ${Azure.V2_0.saksbehandlerAccessToken()}"
 
     @BeforeEach
@@ -33,59 +37,69 @@ internal class HentInstitusjonerTest : AbstractContainerBaseTest() {
     fun tearDown() {
     }
 
+
     @Test
     fun `Forventer at GodkjentOpplæringsinstitusjonDto har riktige typer`(): Unit = runBlocking {
+        val correlationId = UUID.randomUUID().toString()
         val uuid = UUID.randomUUID()
         val institusjonNavn = "Sykehus Test"
         val perioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
-        val gyldigJson = """
+        val forventetJson = """
+            [
                 {
-                    "first": 
-                        [
-                            {
-                                "uuid": "$uuid",
-                                "navn": "$institusjonNavn",
-                                "perioder": [
-                                    {
-                                        "fom": "${perioder.first().fom}",
-                                        "tom": "${perioder.first().tom}"
-                                    }
-                                ]
-                            }
-                        ], 
-                    "second": null
+                    "uuid": "$uuid",
+                    "navn": "$institusjonNavn",
+                    "perioder": [
+                        {
+                            "fom": "${perioder.first().fom}",
+                            "tom": "${perioder.first().tom}"
+                        }
+                    ]
                 }
-                """.trimIndent()
-        val correlationId = UUID.randomUUID().toString()
+            ], 
+            """.trimIndent()
 
         val godkjentOpplæringsinstitusjonDto = GodkjentOpplæringsinstitusjonDto(uuid, institusjonNavn, perioder)
 
-        coEvery { k9SakService.hentInstitusjoner() } returns Pair(listOf(godkjentOpplæringsinstitusjonDto), null)
+        coEvery { k9SakService.hentInstitusjoner() } returns listOf(godkjentOpplæringsinstitusjonDto)
 
         webTestClient.get()
-            .uri { it.path("/api/opplaeringspenger-soknad/institusjoner").build() }
+            .uri { it.path(hentInstitusjonerPunsjUrl).build() }
             .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
             .header(CALL_ID_KEY, correlationId)
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.OK)
             .expectBody()
-            .json(gyldigJson, true)
+            .json(forventetJson, true)
     }
+
 
     @Test
     fun `Forventer at 500 feil hvis vi får ugyldig response`(): Unit = runBlocking {
         val correlationId = UUID.randomUUID().toString()
 
-        val forventetJson = """
-                {
-                    "feil": "Feilet deserialisering"
-                }
-                """.trimIndent()
+        val throwable = Throwable("Feilet ved deserialisering av respons ved henting av institusjoner")
+        coEvery { k9SakService.hentInstitusjoner() } throws RestKallException(
+            titel = "Feil ved henting av institusjoner",
+            message = "Feilet ved deserialisering av respons ved henting av institusjoner: ${throwable.message}",
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+            uri = URI.create(hentInstitusjonerUrl)
+        )
 
-        coEvery { k9SakService.hentInstitusjoner() } returns Pair(null, "Feilet deserialisering")
+        val forventetJson = """
+            {
+                "type": "/problem-details/restkall-feil",
+                "title":"Feil ved henting av institusjoner",
+                "status":500,
+                "detail":"Feilet ved deserialisering av respons ved henting av institusjoner: Feilet ved deserialisering av respons ved henting av institusjoner",
+                "instance":"${hentInstitusjonerPunsjUrl}",
+                "endepunkt":"${hentInstitusjonerUrl}",
+                "correlationId":"${correlationId}"
+            }
+            """.trimIndent()
 
         webTestClient.get()
-            .uri { it.path("/api/opplaeringspenger-soknad/institusjoner").build() }
+            .uri { it.path(hentInstitusjonerPunsjUrl).build() }
             .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
             .header(CALL_ID_KEY, correlationId)
             .exchange()

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/HentInstitusjonerTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/HentInstitusjonerTest.kt
@@ -1,0 +1,96 @@
+package no.nav.k9punsj.opplaeringspenger
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
+import kotlinx.coroutines.runBlocking
+import no.nav.helse.dusseldorf.testsupport.jws.Azure
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
+import no.nav.k9.sak.typer.Periode
+import no.nav.k9punsj.AbstractContainerBaseTest
+import no.nav.k9punsj.CALL_ID_KEY
+import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
+import no.nav.k9punsj.wiremock.saksbehandlerAccessToken
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import java.time.LocalDate
+import java.util.*
+
+internal class HentInstitusjonerTest : AbstractContainerBaseTest() {
+
+    @MockkBean
+    private lateinit var k9SakService: K9SakService
+
+    private val saksbehandlerAuthorizationHeader = "Bearer ${Azure.V2_0.saksbehandlerAccessToken()}"
+
+    @BeforeEach
+    internal fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Test
+    fun `Forventer at GodkjentOpplæringsinstitusjonDto har riktige typer`(): Unit = runBlocking {
+        val uuid = UUID.randomUUID()
+        val institusjonNavn = "Sykehus Test"
+        val perioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
+        val gyldigJson = """
+                {
+                    "first": 
+                        [
+                            {
+                                "uuid": "$uuid",
+                                "navn": "$institusjonNavn",
+                                "perioder": [
+                                    {
+                                        "fom": "${perioder.first().fom}",
+                                        "tom": "${perioder.first().tom}"
+                                    }
+                                ]
+                            }
+                        ], 
+                    "second": null
+                }
+                """.trimIndent()
+        val correlationId = UUID.randomUUID().toString()
+
+        val godkjentOpplæringsinstitusjonDto = GodkjentOpplæringsinstitusjonDto(uuid, institusjonNavn, perioder)
+
+        coEvery { k9SakService.hentInstitusjoner() } returns Pair(listOf(godkjentOpplæringsinstitusjonDto), null)
+
+        webTestClient.get()
+            .uri { it.path("/api/opplaeringspenger-soknad/institusjoner").build() }
+            .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
+            .header(CALL_ID_KEY, correlationId)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.OK)
+            .expectBody()
+            .json(gyldigJson, true)
+    }
+
+    @Test
+    fun `Forventer at 500 feil hvis vi får ugyldig response`(): Unit = runBlocking {
+        val correlationId = UUID.randomUUID().toString()
+
+        val forventetJson = """
+                {
+                    "feil": "Feilet deserialisering"
+                }
+                """.trimIndent()
+
+        coEvery { k9SakService.hentInstitusjoner() } returns Pair(null, "Feilet deserialisering")
+
+        webTestClient.get()
+            .uri { it.path("/api/opplaeringspenger-soknad/institusjoner").build() }
+            .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
+            .header(CALL_ID_KEY, correlationId)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+            .expectBody()
+            .json(forventetJson, true)
+    }
+}

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -1,6 +1,8 @@
 package no.nav.k9punsj.rest.eksternt.k9sak
 
 import no.nav.k9.kodeverk.dokument.Brevkode
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
+import no.nav.k9.sak.typer.Periode
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9.søknad.Søknad
 import no.nav.k9punsj.LokalProfil
@@ -9,14 +11,15 @@ import no.nav.k9punsj.felles.dto.ArbeidsgiverMedArbeidsforholdId
 import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.felles.dto.SaksnummerDto
 import no.nav.k9punsj.felles.dto.SøknadEntitet
-import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
-import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
+import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
+import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import no.nav.k9punsj.util.MockUtil.erFødtI
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.time.Month
+import java.util.*
 
 @Component
 @LokalProfil
@@ -33,6 +36,7 @@ class LokalK9SakService : K9SakService {
             ),
             null
         )
+
         false -> Pair(emptyList(), null)
     }
 
@@ -58,7 +62,7 @@ class LokalK9SakService : K9SakService {
                 no.nav.k9.kodeverk.behandling.FagsakYtelseType.PLEIEPENGER_SYKT_BARN,
                 null,
                 gyldigPeriode = PeriodeDto(LocalDate.parse("2022-08-01"), LocalDate.parse("2022-08-15")),
-                relatertPersonAktørId =  null
+                relatertPersonAktørId = null
             ),
             Fagsak(
                 saksnummer = "DEF456",
@@ -72,6 +76,13 @@ class LokalK9SakService : K9SakService {
                 no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_KS,
                 null,
                 gyldigPeriode = null,
+                relatertPersonAktørId = null
+            ),
+            Fagsak(
+                saksnummer = "JKL123",
+                no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
+                null,
+                gyldigPeriode = PeriodeDto(LocalDate.parse("2022-08-01"), LocalDate.parse("2022-08-15")),
                 relatertPersonAktørId = null
             )
         ),
@@ -119,6 +130,11 @@ class LokalK9SakService : K9SakService {
                 saksnummer = "GHI789",
                 ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_KS,
                 brukerAktørId = "123456789",
+            ),
+            ReservertSaksnummerDto(
+                saksnummer = "JKL123",
+                ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
+                brukerAktørId = "123456789",
             )
         )
     }
@@ -132,5 +148,33 @@ class LokalK9SakService : K9SakService {
         brevkode: Brevkode,
     ) {
         // do nothing
+    }
+
+    override suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?> {
+        val gyldigePerioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
+        return Pair(
+            first = listOf(
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Buskerud (Drammen sykehus)", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset i Vestfold", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Elverum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Gjøvik", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Hamar", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Kongsvinger", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Lillehammer", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Tynset", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Telemark", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Østfold", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Arendal", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Farsund", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Kristiansand", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Mandal", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "St. Olavs Hospital", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Stavanger Universitetssykehus", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sunnaas sykehus", gyldigePerioder),
+            ),
+            second = null
+        )
     }
 }

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -150,31 +150,28 @@ class LokalK9SakService : K9SakService {
         // do nothing
     }
 
-    override suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?> {
+    override suspend fun hentInstitusjoner(): List<GodkjentOpplæringsinstitusjonDto> {
         val gyldigePerioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
-        return Pair(
-            first = listOf(
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Buskerud (Drammen sykehus)", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset i Vestfold", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Elverum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Gjøvik", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Hamar", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Kongsvinger", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Lillehammer", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Tynset", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Telemark", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Østfold", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Arendal", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Farsund", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Kristiansand", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Mandal", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "St. Olavs Hospital", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Stavanger Universitetssykehus", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sunnaas sykehus", gyldigePerioder),
-            ),
-            second = null
+        return listOf(
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Buskerud (Drammen sykehus)", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset i Vestfold", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Elverum", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Gjøvik", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Hamar", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Kongsvinger", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Lillehammer", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Tynset", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Telemark", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Østfold", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Arendal", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Farsund", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Kristiansand", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Mandal", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "St. Olavs Hospital", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Stavanger Universitetssykehus", gyldigePerioder),
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sunnaas sykehus", gyldigePerioder),
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -75,7 +75,7 @@ internal class TestK9SakService : K9SakService {
                 no.nav.k9.kodeverk.behandling.FagsakYtelseType.PLEIEPENGER_SYKT_BARN,
                 null,
                 gyldigPeriode = PeriodeDto(LocalDate.parse("2022-08-01"), LocalDate.parse("2022-08-15")),
-                relatertPersonAktørId =  null
+                relatertPersonAktørId = null
             ),
             Fagsak(
                 saksnummer = "DEF456",
@@ -152,13 +152,10 @@ internal class TestK9SakService : K9SakService {
         // do nothing
     }
 
-    override suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?> {
+    override suspend fun hentInstitusjoner(): List<GodkjentOpplæringsinstitusjonDto> {
         val gyldigePerioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
-        return Pair(
-            first = listOf(
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
-            ),
-            second = null
+        return listOf(
+            GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -90,13 +90,6 @@ internal class TestK9SakService : K9SakService {
                 null,
                 relatertPersonAktørId = null,
                 gyldigPeriode = null
-            ),
-            Fagsak(
-                saksnummer = "JKL123",
-                no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
-                null,
-                gyldigPeriode = PeriodeDto(LocalDate.parse("2022-08-01"), LocalDate.parse("2022-08-15")),
-                relatertPersonAktørId = null
             )
         ),
         second = null
@@ -144,11 +137,6 @@ internal class TestK9SakService : K9SakService {
                 saksnummer = "GHI789",
                 ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_KS,
                 brukerAktørId = "123456789",
-            ),
-            ReservertSaksnummerDto(
-                saksnummer = "JKL123",
-                ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
-                brukerAktørId = "123456789",
             )
         )
     }
@@ -169,24 +157,6 @@ internal class TestK9SakService : K9SakService {
         return Pair(
             first = listOf(
                 GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Buskerud (Drammen sykehus)", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset i Vestfold", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Elverum", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Gjøvik", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Hamar", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Kongsvinger", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Lillehammer", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Tynset", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Telemark", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Østfold", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Arendal", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Farsund", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Kristiansand", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Mandal", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "St. Olavs Hospital", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Stavanger Universitetssykehus", gyldigePerioder),
-                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sunnaas sykehus", gyldigePerioder),
             ),
             second = null
         )

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -1,6 +1,8 @@
 package no.nav.k9punsj.rest.eksternt.k9sak
 
 import no.nav.k9.kodeverk.dokument.Brevkode
+import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
+import no.nav.k9.sak.typer.Periode
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9.søknad.Søknad
 import no.nav.k9punsj.felles.PunsjFagsakYtelseType
@@ -10,11 +12,12 @@ import no.nav.k9punsj.felles.dto.SaksnummerDto
 import no.nav.k9punsj.felles.dto.SøknadEntitet
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
-import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
+import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.util.*
 
 @Component
 @Profile("test") // TODO: Erstatt med mock
@@ -87,6 +90,13 @@ internal class TestK9SakService : K9SakService {
                 null,
                 relatertPersonAktørId = null,
                 gyldigPeriode = null
+            ),
+            Fagsak(
+                saksnummer = "JKL123",
+                no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
+                null,
+                gyldigPeriode = PeriodeDto(LocalDate.parse("2022-08-01"), LocalDate.parse("2022-08-15")),
+                relatertPersonAktørId = null
             )
         ),
         second = null
@@ -134,6 +144,11 @@ internal class TestK9SakService : K9SakService {
                 saksnummer = "GHI789",
                 ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OMSORGSPENGER_KS,
                 brukerAktørId = "123456789",
+            ),
+            ReservertSaksnummerDto(
+                saksnummer = "JKL123",
+                ytelseType = no.nav.k9.kodeverk.behandling.FagsakYtelseType.OPPLÆRINGSPENGER,
+                brukerAktørId = "123456789",
             )
         )
     }
@@ -147,5 +162,33 @@ internal class TestK9SakService : K9SakService {
         brevkode: Brevkode,
     ) {
         // do nothing
+    }
+
+    override suspend fun hentInstitusjoner(): Pair<List<GodkjentOpplæringsinstitusjonDto>?, String?> {
+        val gyldigePerioder = listOf(Periode(LocalDate.now().minusMonths(12), LocalDate.now()))
+        return Pair(
+            first = listOf(
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Buskerud (Drammen sykehus)", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset i Vestfold", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehus Asker/Bærum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Elverum", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Gjøvik", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Hamar", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Kongsvinger", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Lillehammer", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Innlandet Tynset", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Telemark", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sykehuset Østfold", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Arendal", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Farsund", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Kristiansand", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sørlandet sykehus, Mandal", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "St. Olavs Hospital", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Stavanger Universitetssykehus", gyldigePerioder),
+                GodkjentOpplæringsinstitusjonDto(UUID.randomUUID(), "Sunnaas sykehus", gyldigePerioder),
+            ),
+            second = null
+        )
     }
 }


### PR DESCRIPTION
## Bakgrunn
Opplæringspenger skal inn i K9. For å lette saksbehandlingen ønsker vi en liste over godkjente institusjoner som saksbehandler kan velge mellom i frontend.

## Løsning
Lager et endepunkt her i `k9-punsj` som kaller `k9-sak` og finner en liste over godkjente institusjoner.