### PR TITLE
Bug fix OMPUT

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/MapOmsUtTilK9Format.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/MapOmsUtTilK9Format.kt
@@ -126,7 +126,21 @@ internal class MapOmsUtTilK9Format(
             val normalArbeidstid: Duration? = fraværsPeriode.normalArbeidstid?.somDuration()
             val fraværÅrsak: FraværÅrsak? = fraværsPeriode.fraværÅrsak
             val søknadÅrsak: SøknadÅrsak? = fraværsPeriode.søknadÅrsak
+
+            // Validate aktivitetsFravær
+            if (fraværsPeriode.aktivitetsFravær == null) {
+                feil.add(
+                        Feil(
+                                "fraværsPerioder[$index].aktivitetsFravær",
+                                null,
+                                "aktivitetsFravær kan ikke være null"
+                        )
+                )
+                return@mapIndexed null // Skip processing this entry
+            }
+
             val aktivitetFravær: List<AktivitetFravær> = listOf(fraværsPeriode.aktivitetsFravær)
+
             if (AktivitetFravær.ARBEIDSTAKER == fraværsPeriode.aktivitetsFravær && fraværsPeriode.organisasjonsnummer.isNullOrEmpty()) {
                 feil.add(
                     Feil(

--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingSøknadDto.kt
@@ -41,7 +41,7 @@ data class OmsorgspengerutbetalingSøknadDto(
     val k9saksnummer: String? = null
 ) {
     data class FraværPeriode(
-        val aktivitetsFravær: AktivitetFravær,
+        val aktivitetsFravær: AktivitetFravær?,
         val organisasjonsnummer: String? = null,
         val periode: PeriodeDto,
         val fraværÅrsak: FraværÅrsak?,


### PR DESCRIPTION
Feil ved henting av eksisterende søknader i OMPUT
Årsaken til feilen er mellomlagring. Det opprettes tomme aktivitetsfravær for arbeidstaker, frilanser og selvstendig næringsdrivende (SN).
Disse kan mellomlagres og åpnes ved bruk av søknads-ID. Men dersom det er behov for å hente alle eksisterende påbegynte registreringer, oppstår det en feil ved konverteringen til en liste av typen OmsorgspengerutbetalingSøknad.