### PR TITLE
Migrerer fra Foedsel til Foedselsdato ved henting av personBolk fra PDL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,17 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.4.0-b180830.0438</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!--PDF-->
     </dependencies>
 
@@ -340,8 +351,8 @@
     </repositories>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -350,6 +361,23 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <args>
                         <arg>-Xjsr305=strict</arg>
@@ -357,6 +385,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
+                    <jvmTarget>21</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -369,6 +398,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/pdl/PdlResponseMapping.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/pdl/PdlResponseMapping.kt
@@ -22,7 +22,7 @@ internal fun ObjectNode.mapPersonopplysninger(): Set<Personopplysninger> {
             val folkeregisteridentifikator = (person.get("folkeregisteridentifikator") as ArrayNode).first()
             Personopplysninger(
                 identitetsnummer = folkeregisteridentifikator.get("identifikasjonsnummer").asText(),
-                fødselsdato = LocalDate.parse((person.get("foedsel") as ArrayNode).first().get("foedselsdato").asText()),
+                fødselsdato = LocalDate.parse((person.get("foedselsdato") as ArrayNode).first().get("foedselsdato").asText()),
                 gradering = (person.get("adressebeskyttelse") as ArrayNode).firstOrNull()?.get("gradering")?.asText().fraPdlDto(),
                 fornavn = navn.get("fornavn").asText(),
                 mellomnavn = when (navn.hasNonNull("mellomnavn")) {

--- a/src/main/resources/pdl/hent-personopplysninger.graphql
+++ b/src/main/resources/pdl/hent-personopplysninger.graphql
@@ -8,7 +8,7 @@ query($identer: [ID!]!) {
             navn(historikk: false) {
                 fornavn, mellomnavn, etternavn
             },
-            foedsel {
+            foedselsdato {
                 foedselsdato
             },
             adressebeskyttelse(historikk: false) {

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/pdl/PdlResponseMappingTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/pdl/PdlResponseMappingTest.kt
@@ -61,7 +61,7 @@ internal class PdlResponseMappingTest {
                                 "mellomnavn": null,
                                 "etternavn": "NORDMANN"
                             }],
-                            "foedsel": [{
+                            "foedselsdato": [{
                                 "foedselsdato": "1980-12-02"
                             }],
                             "adressebeskyttelse": []
@@ -78,7 +78,7 @@ internal class PdlResponseMappingTest {
                                 "mellomnavn": "MELLOMSTE",
                                 "etternavn": "NORDMANN"
                             }],
-                            "foedsel": [{
+                            "foedselsdato": [{
                                 "foedselsdato": "1990-12-02"
                             }],
                             "adressebeskyttelse": [{


### PR DESCRIPTION
### Bakgrunn
PDL faser ut opplysningen `Foedsel`, og alle konsumenter som bruker denne denne opplysningen må gå over til `Foedselsdato`.

### Løsning
- Erstatter `Foedsel` med `Foedselsdato` i `hent-personopplysninger.graphql`.
- Refaktorerer `PdlResponseMapping.kt` til å hente ut `Foedselsdato` fra responsen.

### Andre endringer
- Fikser pom.xml etter oppgradering til kotlin 2.1