### PR TITLE
TSFF-1668: Fiks mapping av søknadsperiode fra kursperioder

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
@@ -152,8 +152,8 @@ internal class MapOlpTilK9Format(
         } else {
             // Utleder søknadsperiode fra kursperioder
             if (this.kurs != null) {
-                this.kurs.utledsSoeknadsPeriodeFraKursperioder()?.map { kursPeriode ->
-                    opplaeringspenger.medSøknadsperiode(kursPeriode.somK9Periode())
+                this.kurs.kursperioder?.map { kursPeriode ->
+                    opplaeringspenger.medSøknadsperiode(kursPeriode.periode.somK9Periode())
                 }
             }
         }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadDto.kt
@@ -67,13 +67,7 @@ data class OpplaeringspengerSøknadDto(
         val kursHolder: KursHolder?,
         val kursperioder: List<KursPeriode>?,
         val reise: Reise?
-    ) {
-        fun utledsSoeknadsPeriodeFraKursperioder(): List<PeriodeDto>? {
-            return kursperioder?.map { kursPeriode ->
-                PeriodeDto(fom = kursPeriode.periode.fom, tom = kursPeriode.periode.tom)
-            }
-        }
-    }
+    )
 
     data class BegrunnelseForInnsendingDto(
         val tekst: String

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
@@ -25,41 +25,6 @@ internal class MapOlpTilK9FormatTest {
     }
 
     @Test
-    fun `Kurs med flere kursperioder utleder søknadsperiode fra første o siste dato i perioderna`() {
-        val periode1 = KursPeriode(
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 1, 5)
-        )
-        val periode2 = KursPeriode(
-            LocalDate.of(2023, 1, 8),
-            LocalDate.of(2023, 1, 10)
-        )
-        val periode3 = KursPeriode(
-            LocalDate.of(2023, 1, 20),
-            LocalDate.of(2023, 1, 29)
-        )
-
-        val kurs = OpplaeringspengerSøknadDto.Kurs(
-            kursHolder = OpplaeringspengerSøknadDto.KursHolder(holder = "test", institusjonsUuid = null),
-            kursperioder = listOf(periode3, periode1, periode2),
-            reise = OpplaeringspengerSøknadDto.Reise(
-                reisedager = listOf(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 29)),
-                reisedagerBeskrivelse = "borte bra, hjemme best"
-            )
-        )
-
-        val søknadsperiode = kurs.utledsSoeknadsPeriodeFraKursperioder()
-
-        assert(søknadsperiode != null)
-        assert(søknadsperiode?.get(0)?.fom == periode3.periode.fom)
-        assert(søknadsperiode?.get(0)?.tom == periode3.periode.tom)
-        assert(søknadsperiode?.get(1)?.fom == periode1.periode.fom)
-        assert(søknadsperiode?.get(1)?.tom == periode1.periode.tom)
-        assert(søknadsperiode?.get(2)?.fom == periode2.periode.fom)
-        assert(søknadsperiode?.get(2)?.tom == periode2.periode.tom)
-    }
-
-    @Test
     fun `test json-payload mapper o validerer`() {
         val json = """
             {


### PR DESCRIPTION
### **Behov / Bakgrunn**
I mappingen fra kursperioder til søknadsperioder slår vi sammen flere kursperioder til en sammenhengende søknadsperiode. Slik skal det ikke være. Kursperiodene skal være de samme som søknadsperiodene. 

Jira: https://jira.adeo.no/browse/TSFF-1668

### **Løsning**
- Map ut alle kursperiodene til søknadsperioder. 
- Legg også til en null sjekk på kurs nå som kurs kan være null
