### PR TITLE
TSFF-1464: Hvis vi hverken får institusjonsUuid eller navn setter vi kurs = null

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
@@ -109,6 +109,11 @@ internal class MapOlpTilK9Format(
 
 
     private fun OpplaeringspengerSøknadDto.Kurs.leggTilKurs() {
+        // hvis hverken institusjonsUuid eller holder er satt, så skal ikke kurs legges til
+        if (this.kursHolder?.institusjonsUuid.isNullOrBlank() && this.kursHolder?.holder.isNullOrBlank()) {
+            return
+        }
+
         val institusjonsUuid = this.kursHolder?.institusjonsUuid?.let {
             try {
                 UUID.fromString(it)


### PR DESCRIPTION
### **Behov / Bakgrunn**
Ved trekk av periode skal man ikke trenge å sette institusjon. 

Jira: https://jira.adeo.no/browse/TSFF-1464

### **Løsning**
Hvis vi hverken får inn kursHolder.institusjonsUuid eller kursHolder.holder, setter vi kurs = null
