### PR TITLE
Fiks Microsoft Graph API integrasjon for k9-punsj i test-miljø

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/azuregraph/OfficeLocation.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/azuregraph/OfficeLocation.kt
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class OfficeLocation(
     @JsonProperty("@odata.context")
     val odataContext: String,
-    val officeLocation: String
+    val officeLocation: String? = null,
+    val streetAddress: String? = null
 )


### PR DESCRIPTION
## Behov / Bakgrunn

k9-punsj feiler på `/api/notat/opprett` i VTP fordi den har hardkodet Microsoft Graph API kall med feil audience.

## Løsning

- Legg til `MS_GRAPH_URL` miljøvariabel for VTP test-miljø
- Implementer fallback fra `officeLocation` til `streetAddress` 
- Behold produksjons-funksjonalitet uendret