### PR TITLE
 Fjern idType fra avsenderMottaker i DokarkivGateway (dokarkivPayload) for å fikse 400 Bad Request

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGateway.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGateway.kt
@@ -376,8 +376,7 @@ data class JournalPostRequest(
               "eksternReferanseId": "$eksternReferanseId",
               "tittel": "$tittel",
               "avsenderMottaker": {
-                "navn": "$avsenderNavn",
-                "idType": "FNR"
+                "navn": "$avsenderNavn"
               },
               "bruker": {
                 "id": "$brukerIdent",


### PR DESCRIPTION
### **Behov / Bakgrunn**
Q Dokarkiv API returnerer 400 Bad Request når k9-punsj sender `avsenderMottaker` med `idType` felt uten tilhørende `id` felt.

400 BAD_REQUEST "Kunne ikke opprette journalpost. Oppdatering av avsenderMottaker.idType krever at feltet avsenderMottaker.id er satt. Mottatt id=null idType=FNR"

- VTP mock krever `idType: "..."` felt i `avsenderMottaker` uten 'id'

### **Løsning**
Fjernet `idType` felt fra `avsenderMottaker` objekt i `DokarkivGateway.kt`:

