### PR TITLE
TSFF-1871: Fjern medisinske opplysninger fra OLP PDF

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/domenetjenester/MappeService.kt
@@ -58,7 +58,6 @@ internal class MappeService(
                 mottattDato = søknadfelles.mottattDato?.toLocalDate(),
                 klokkeslett = søknadfelles.klokkeslett,
                 harInfoSomIkkeKanPunsjes = false,
-                harMedisinskeOpplysninger = false,
                 k9saksnummer = nySøknad.k9saksnummer
             )
 

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9Format.kt
@@ -188,7 +188,6 @@ internal class MapOlpTilK9Format(
                 Journalpost()
                     .medJournalpostId(journalpostId)
                     .medInformasjonSomIkkeKanPunsjes(harInfoSomIkkeKanPunsjes)
-                    .medInneholderMedisinskeOpplysninger(harMedisinskeOpplysninger)
             )
         }
     }

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadDto.kt
@@ -33,7 +33,6 @@ data class OpplaeringspengerSøknadDto(
     val omsorg: OmsorgDto? = null,
     val kurs: Kurs? = null,
     val harInfoSomIkkeKanPunsjes: Boolean,
-    val harMedisinskeOpplysninger: Boolean,
     val begrunnelseForInnsending: BegrunnelseForInnsendingDto? = null,
     val metadata: Map<*, *>? = null,
     val k9saksnummer: String? = null
@@ -119,7 +118,6 @@ internal fun Mappe.tilOlpVisning(norskIdent: String): SvarOlpDto {
                     soeknadId = s.søknadId,
                     soekerId = norskIdent,
                     journalposter = hentUtJournalposter(s),
-                    harMedisinskeOpplysninger = false,
                     harInfoSomIkkeKanPunsjes = false,
                     k9saksnummer = s.k9saksnummer
                 )
@@ -134,7 +132,6 @@ internal fun SøknadEntitet.tilOlpvisning(): OpplaeringspengerSøknadDto {
             soeknadId = this.søknadId,
             journalposter = hentUtJournalposter(this),
             harInfoSomIkkeKanPunsjes = false,
-            harMedisinskeOpplysninger = false
         )
     }
     return objectMapper().convertValue(søknad)

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
@@ -37,7 +37,6 @@ internal class MapOlpTilK9FormatTest {
               "begrunnelseForInnsending": { "tekst": "" },
               "bosteder": [],
               "harInfoSomIkkeKanPunsjes": false,
-              "harMedisinskeOpplysninger": true,
               "journalposter": ["200"],
               "klokkeslett": "12:53",
               "kurs": {

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadVisningDtoUtils.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerSoknadVisningDtoUtils.kt
@@ -168,7 +168,6 @@ internal object OpplaeringspengerSoknadVisningDtoUtils {
             harMedsoeker = null
         ),
         harInfoSomIkkeKanPunsjes = true,
-        harMedisinskeOpplysninger = true,
         trekkKravPerioder = setOf(requiredPeriode),
         begrunnelseForInnsending = OpplaeringspengerSøknadDto.BegrunnelseForInnsendingDto("fordi dette er ett test"),
         kurs = OpplaeringspengerSøknadDto.Kurs(


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har ikke behov for å markere punsj innsendinger med harMedisinskeOpplysninger.

Jira: https://jira.adeo.no/browse/TSFF-1871

### **Løsning**
Fjerner harMedisinskeOpplysninger 