### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/src/test/kotlin/no/nav/k9punsj/K9PunsjApplicationTests.kt
+++ b/src/test/kotlin/no/nav/k9punsj/K9PunsjApplicationTests.kt
@@ -78,7 +78,7 @@ class K9PunsjApplicationTests : AbstractContainerBaseTest() {
                 """
                 {
                     "journalpostId": "1",
-                    "norskIdent": "29099000129",
+                    "norskIdent": "24420167209",
                     "dokumenter": [
                         {
                             "dokumentId": "470164680"

--- a/src/test/kotlin/no/nav/k9punsj/db/repository/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/db/repository/SøknadRepositoryTest.kt
@@ -19,7 +19,7 @@ import java.util.*
 
 internal class SøknadRepositoryTest: AbstractContainerBaseTest() {
 
-    private val standardIdent = "01122334410"
+    private val standardIdent = "24420167209"
     private val standardAktørId = "1000000000000"
 
     private val barnIdent = "01122334412"

--- a/src/test/kotlin/no/nav/k9punsj/domenetjenester/MappeServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/domenetjenester/MappeServiceTest.kt
@@ -19,7 +19,7 @@ import java.util.*
 class MappeServiceTest: AbstractContainerBaseTest() {
 
     private companion object {
-        private val standardIdent = "01122334410"
+        private val standardIdent = "24420167209"
         private val standardAktørId = "1000000000000"
 
         private val barnIdent = "01122334412"

--- a/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadIntegrasjonsTest.kt
@@ -27,7 +27,7 @@ internal class SoknadIntegrasjonsTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Sender in søknad mottatt 2023 til k9 for OMS 2022 og får riktig saksnummer`(): Unit = runBlocking {
-        val norskIdent = "03011939596"
+        val norskIdent = "26470392885"
         val soeknadJson: SøknadJson = LesFraFilUtil.søknadFraFrontendOmsUt2022()
         val journalpostid = FerdigstiltMedSaksnummer
         tilpasserSøknadsMalTilTesten(soeknadJson, norskIdent, journalpostid)

--- a/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/domenetjenester/SoknadServiceTest.kt
@@ -166,7 +166,7 @@ internal class SoknadServiceTest {
         coEvery { pdlService.hentPersonopplysninger(any()) }.returns(
             setOf(
                 Personopplysninger(
-                    identitetsnummer = "21040076619",
+                    identitetsnummer = "15490357286",
                     fødselsdato = LocalDateTime.now().toLocalDate(),
                     fornavn = "fornavn",
                     mellomnavn = "mellomnavn",
@@ -185,10 +185,10 @@ internal class SoknadServiceTest {
                 PleiepengerSyktBarn()
                     .medBarn(
                         Barn()
-                            .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("20032390359"))
+                            .medNorskIdentitetsnummer(NorskIdentitetsnummer.of("26470392885"))
                     )
             )
-            .medSøker(Søker(NorskIdentitetsnummer.of("21040076619")))
+            .medSøker(Søker(NorskIdentitetsnummer.of("15490357286")))
 
         val result = soknadService.sendSøknad(
             søknad = søknad,

--- a/src/test/kotlin/no/nav/k9punsj/gosys/GosysRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/gosys/GosysRoutesTest.kt
@@ -30,7 +30,7 @@ internal class GosysRoutesTest: AbstractContainerBaseTest() {
         val body = """
         {
           "journalpostId": "${JournalpostIds.Ok}",
-          "norskIdent": "29099000129"
+          "norskIdent": "24420167209"
         }
         """.trimIndent()
 
@@ -49,7 +49,7 @@ internal class GosysRoutesTest: AbstractContainerBaseTest() {
         val body = """
         {
           "journalpostId": "${JournalpostIds.Ok}",
-          "norskIdent": "29099000129",
+          "norskIdent": "24420167209",
           "gjelder": "PleiepengerPårørende"
         }
         """.trimIndent()

--- a/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/integrasjoner/arbeidsgivere/ArbeidsgivereRoutesTest.kt
@@ -99,7 +99,7 @@ internal class ArbeidsgivereRoutesTest : AbstractContainerBaseTest() {
             }
             .accept(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
-            .header("X-Nav-NorskIdent", "22053826656")
+            .header("X-Nav-NorskIdent", "11410183759")
             .exchange()
             .expectStatus().isOk
             .expectBody().json(forventetResponse)

--- a/src/test/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGatewayTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/integrasjoner/dokarkiv/DokarkivGatewayTest.kt
@@ -28,7 +28,7 @@ class DokarkivGatewayTest {
                 )
             ),
             bruker = FerdigstillJournalpost.Bruker(
-                identitetsnummer = "15069205221".somIdentitetsnummer(),
+                identitetsnummer = "18410162721".somIdentitetsnummer(),
                 sak = Pair(Fagsystem.K9SAK, saksnummer),
                 navn = "Pessimistisk Bildekort"
             ),
@@ -56,7 +56,7 @@ class DokarkivGatewayTest {
                 )
             ),
             bruker = FerdigstillJournalpost.Bruker(
-                identitetsnummer = "15069205221".somIdentitetsnummer(),
+                identitetsnummer = "18410162721".somIdentitetsnummer(),
                 sak = Pair(Fagsystem.K9SAK, saksnummer),
                 navn = "Pessimistisk Bildekort"
             ),

--- a/src/test/kotlin/no/nav/k9punsj/journalpost/KopierJournalpostRouteTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/journalpost/KopierJournalpostRouteTest.kt
@@ -97,7 +97,7 @@ internal class KopierJournalpostRouteTest : AbstractContainerBaseTest() {
 
         when (ytelseType) {
             PLEIEPENGER_SYKT_BARN, PLEIEPENGER_LIVETS_SLUTTFASE, OMSORGSPENGER_MIDLERTIDIG_ALENE, OMSORGSPENGER_KRONISK_SYKT_BARN, OMSORGSPENGER_ALENE_OMSORGEN -> {
-                val barnEllerAnnenPart = "05032435485"
+                val barnEllerAnnenPart = "11410183759"
                 KopierJournalpostDto(
                     til = søkerAktørId,
                     barn = barnEllerAnnenPart,
@@ -190,7 +190,7 @@ internal class KopierJournalpostRouteTest : AbstractContainerBaseTest() {
         val journalpostId = IdGenerator.nesteId()
         val saksnummer = "ABC123"
         val søkerAktørId = "27519339353"
-        val barn = "05032435485"
+        val barn = "11410183759"
 
         Mockito.`when`(safGateway.hentJournalpostInfo(journalpostId)).thenReturn(
             SafDtos.Journalpost(
@@ -274,7 +274,7 @@ internal class KopierJournalpostRouteTest : AbstractContainerBaseTest() {
         val journalpostId = IdGenerator.nesteId()
         val saksnummer = "ABC123"
         val søkerAktørId = "27519339353"
-        val barn = "05032435485"
+        val barn = "11410183759"
 
         Mockito.`when`(safGateway.hentJournalpostInfo(journalpostId)).thenReturn(
             SafDtos.Journalpost(

--- a/src/test/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingDtoRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/korrigeringinntektsmelding/KorrigeringInntektsmeldingDtoRoutesTest.kt
@@ -54,7 +54,7 @@ class KorrigeringInntektsmeldingDtoRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val opprettNySøknad = opprettSøknad(norskIdent, UUID.randomUUID().toString())
 
         opprettNySøknad(opprettNySøknad)
@@ -62,7 +62,7 @@ class KorrigeringInntektsmeldingDtoRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Hente eksisterende mappe på person`(): Unit = runBlocking {
-        val norskIdent = "02020050163"
+        val norskIdent = "18410162721"
         val journalpostId = UUID.randomUUID().toString()
         val opprettNySøknad = opprettSøknad(norskIdent, journalpostId)
 

--- a/src/test/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/omsorgspengeraleneomsorg/OmsorgspengerAleneOmsorgRoutesTest.kt
@@ -47,7 +47,7 @@ internal class OmsorgspengerAleneOmsorgRoutesTest : AbstractContainerBaseTest() 
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val pleietrengende = "01010050023"
         val opprettNySøknad = opprettSøknad(norskIdent, UUID.randomUUID().toString(), pleietrengende)
 

--- a/src/test/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/omsorgspengerkronisksyktbarn/OmsorgspengerKroniskSyktBarnRoutesTest.kt
@@ -51,8 +51,8 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
-        val pleietrengendeIdent = "02020050163"
+        val norskIdent = "17420373147"
+        val pleietrengendeIdent = "18410162721"
         val opprettNySøknad = opprettSøknad(norskIdent, pleietrengendeIdent, UUID.randomUUID().toString())
 
         opprettNySøknad(opprettNySøknad)
@@ -61,8 +61,8 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Hente eksisterende mappe på person`(): Unit = runBlocking {
-        val norskIdent = "02020050163"
-        val pleietrengendeIdent = "01010050053"
+        val norskIdent = "18410162721"
+        val pleietrengendeIdent = "17420373147"
         val journalpostId = UUID.randomUUID().toString()
         val opprettNySøknad = opprettSøknad(norskIdent, pleietrengendeIdent, journalpostId)
 
@@ -80,7 +80,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
     fun `Hent en søknad`(): Unit = runBlocking {
         val søknad = LesFraFilUtil.søknadFraFrontendOmsKSB()
         val norskIdent = "02030050163"
-        val pleietrengendeIdent = "01010050053"
+        val pleietrengendeIdent = "17420373147"
         val journalpostid = abs(Random(2224).nextInt()).toString()
         tilpasserSøknadsMalTilTesten(søknad, norskIdent, journalpostid)
 
@@ -101,7 +101,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
     fun `Oppdaterer en søknad`(): Unit = runBlocking {
         val søknadFraFrontend = LesFraFilUtil.søknadFraFrontendOmsKSB()
         val norskIdent = "02030050163"
-        val pleietrengendeIdent = "01010050053"
+        val pleietrengendeIdent = "17420373147"
         val journalpostid = abs(Random(1234).nextInt()).toString()
         tilpasserSøknadsMalTilTesten(søknadFraFrontend, norskIdent, journalpostid)
 
@@ -124,7 +124,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
     fun `Oppdaterer en søknad med metadata`(): Unit = runBlocking {
         val søknadFraFrontend = LesFraFilUtil.søknadFraFrontendOmsKSB()
         val norskIdent = "02030050163"
-        val pleietrengendeIdent = "01010050053"
+        val pleietrengendeIdent = "17420373147"
         val journalpostid = abs(Random(1234).nextInt()).toString()
         tilpasserSøknadsMalTilTesten(søknadFraFrontend, norskIdent, journalpostid)
 
@@ -161,7 +161,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
         opprettOgSendInnSoeknad(
             soeknadJson = gyldigSoeknad,
             ident = norskIdent,
-            pleietrengendeIdent = "01010050053",
+            pleietrengendeIdent = "17420373147",
             journalpostid = journalpostid
         )
         assertThat(journalpostRepository.kanSendeInn(listOf(journalpostid))).isFalse
@@ -170,7 +170,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
     @Test
     fun `Skal verifisere at søknad er ok`(): Unit = runBlocking {
         val norskIdent = "02022352122"
-        val pleietrengendeIdent = "01010050053"
+        val pleietrengendeIdent = "17420373147"
         val soeknad: SøknadJson = LesFraFilUtil.søknadFraFrontendOmsKSB()
         val journalpostid = abs(Random(234234).nextInt()).toString()
         tilpasserSøknadsMalTilTesten(soeknad, norskIdent, journalpostid)
@@ -187,7 +187,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
     @Test
     fun `Skal kunne lagre flagg om medisinske og punsjet`(): Unit = runBlocking {
         val norskIdent = "02022352121"
-        val pleietrengendeIdent = "01010050053"
+        val pleietrengendeIdent = "17420373147"
         val soeknad: SøknadJson = LesFraFilUtil.søknadFraFrontendOmsKSB()
         tilpasserSøknadsMalTilTesten(soeknad, norskIdent)
 
@@ -231,7 +231,7 @@ class OmsorgspengerKroniskSyktBarnRoutesTest : AbstractContainerBaseTest() {
         opprettOgLagreSoeknad(
             soeknadJson = soeknadJson,
             ident = norskIdent,
-            pleietrengendeIdent = "01010050053",
+            pleietrengendeIdent = "17420373147",
             journalpostid = journalpostid
         )
 

--- a/src/test/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneRoutesTest.kt
@@ -45,7 +45,7 @@ internal class OmsorgspengerMidlertidigAleneRoutesTest : AbstractContainerBaseTe
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val pleietrengende = "01010050023"
         val opprettNySøknad = opprettSøknad(
             personnummer = norskIdent,

--- a/src/test/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingRoutesTest.kt
@@ -54,7 +54,7 @@ class OmsorgspengerutbetalingRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val opprettNySøknad = opprettSøknad(norskIdent, UUID.randomUUID().toString())
 
         opprettNySøknad(opprettNySøknad).expectStatus().isCreated
@@ -62,7 +62,7 @@ class OmsorgspengerutbetalingRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Hente eksisterende mappe på person`(): Unit = runBlocking {
-        val norskIdent = "02020050163"
+        val norskIdent = "18410162721"
         val journalpostId = UUID.randomUUID().toString()
         val opprettNySøknad = opprettSøknad(norskIdent, journalpostId)
 
@@ -196,9 +196,9 @@ class OmsorgspengerutbetalingRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Korrigering OMP UT med fraværsperioder fra tidiger år validerer riktigt år`(): Unit = runBlocking {
-        // 03011939596 på OMS har två perioder i k9sak fra december 2022.
+        // 26470392885 på OMS har två perioder i k9sak fra december 2022.
         // OmsUtKorrigering fjerner første perioden i 2022.
-        val norskIdent = "03011939596"
+        val norskIdent = "26470392885"
         val soeknad: SøknadJson = LesFraFilUtil.søknadFraFrontendOmsUtKorrigering()
         val journalpostid = abs(Random(234234).nextInt()).toString()
         tilpasserSøknadsMalTilTesten(soeknad, norskIdent, journalpostid)

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/MapOlpTilK9FormatTest.kt
@@ -33,7 +33,7 @@ internal class MapOlpTilK9FormatTest {
                 "frilanserArbeidstidInfo": null,
                 "selvstendigNæringsdrivendeArbeidstidInfo": null
               },
-              "barn": { "norskIdent": "03091477490", "foedselsdato": "" },
+              "barn": { "norskIdent": "15490357286", "foedselsdato": "" },
               "begrunnelseForInnsending": { "tekst": "" },
               "bosteder": [],
               "journalposter": ["200"],
@@ -64,7 +64,7 @@ internal class MapOlpTilK9FormatTest {
                 "selvstendigNaeringsdrivende": null,
                 "frilanser": null
               },
-              "soekerId": "29099000129",
+              "soekerId": "24420167209",
               "soeknadId": "c9f9d5aa-535d-4da3-af8b-76e245ed1794",
               "soeknadsperiode": null,
               "soknadsinfo": { "samtidigHjemme": null, "harMedsøker": null },

--- a/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerTests.kt
+++ b/src/test/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerTests.kt
@@ -24,7 +24,7 @@ class OpplaeringspengerTests {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val opprettNySøknad = opprettSøknad(norskIdent, "999")
         val status = client.post()
             .uri { it.pathSegment(api, søknadTypeUri).build() }
@@ -36,7 +36,7 @@ class OpplaeringspengerTests {
 
     @Test
     fun `Hente eksisterende mappe på person`(): Unit = runBlocking {
-        val norskIdent = "02020050163"
+        val norskIdent = "18410162721"
         val opprettNySøknad = opprettSøknad(norskIdent, "9999")
 
         val status = client.post()

--- a/src/test/kotlin/no/nav/k9punsj/person/LokalBarnService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/person/LokalBarnService.kt
@@ -12,13 +12,13 @@ internal class LokalBarnService : BarnService {
     override suspend fun hentBarn(identitetsnummer: String): Set<Barn> = when {
         identitetsnummer.erFødtI(Month.MAY) -> setOf(
             Barn(
-                identitetsnummer = "09018070097", // Tilfeldig genrerert gyldig fnr
+                identitetsnummer = "13480175462", // Tilfeldig genrerert gyldig fnr
                 fødselsdato = LocalDate.now().minusYears(10),
                 fornavn = "Ola",
                 etternavn = "Nordmann"
             ),
             Barn(
-                identitetsnummer = "08078374668",
+                identitetsnummer = "14510058187",
                 fødselsdato = LocalDate.now().minusYears(5).minusMonths(5),
                 fornavn = "Kari",
                 mellomnavn = "Mellomste", // Tilfeldig genrerert gyldig fnr

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseRoutesTest.kt
@@ -48,7 +48,7 @@ class PleiepengerLivetsSluttfaseRoutesTest : AbstractContainerBaseTest() {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val pleietrengende = "01010050023"
         val opprettNySøknad = opprettSøknad(norskIdent, UUID.randomUUID().toString(), pleietrengende)
 

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengersyktbarnTests.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengersyktbarnTests.kt
@@ -61,7 +61,7 @@ class PleiepengersyktbarnTests : AbstractContainerBaseTest() {
 
     @Test
     fun `Opprette ny mappe på person`(): Unit = runBlocking {
-        val norskIdent = "01010050053"
+        val norskIdent = "17420373147"
         val opprettNySøknad = opprettSøknad(norskIdent, "999")
 
         opprettNySøknad(opprettNySøknad).expectStatus().isCreated
@@ -69,7 +69,7 @@ class PleiepengersyktbarnTests : AbstractContainerBaseTest() {
 
     @Test
     fun `Hente eksisterende mappe på person`(): Unit = runBlocking {
-        val norskIdent = "02020050163"
+        val norskIdent = "18410162721"
         val opprettNySøknad = opprettSøknad(norskIdent, "9999", "DEF456")
 
         opprettNySøknad(opprettNySøknad).expectStatus().isCreated

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -29,7 +29,7 @@ internal class TestK9SakService : K9SakService {
         punsjFagsakYtelseType: PunsjFagsakYtelseType
     ): Pair<List<PeriodeDto>?, String?> {
         // OmsorgspengerutbetalingRoutesTest.Korrigering OMP UT med fraværsperioder fra tidiger år validerer riktigt år
-        if (søker == "03011939596" && punsjFagsakYtelseType == PunsjFagsakYtelseType.OMSORGSPENGER) {
+        if (søker == "26470392885" && punsjFagsakYtelseType == PunsjFagsakYtelseType.OMSORGSPENGER) {
             return Pair(
                 listOf(
                     PeriodeDto(

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/pdl/TestPdlService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/pdl/TestPdlService.kt
@@ -115,9 +115,9 @@ internal class TestPdlService : PdlService {
                 gradering = Personopplysninger.Gradering.UGRADERT
             )
         )
-        setOf("03011939596") -> setOf( // SoknadService
+        setOf("26470392885") -> setOf( // SoknadService
             Personopplysninger(
-                identitetsnummer = "03011939596",
+                identitetsnummer = "26470392885",
                 fødselsdato = LocalDate.parse("1980-05-06"),
                 fornavn = "Anders",
                 mellomnavn = "OMPUT",

--- a/src/test/kotlin/no/nav/k9punsj/wiremock/AaregMocks.kt
+++ b/src/test/kotlin/no/nav/k9punsj/wiremock/AaregMocks.kt
@@ -13,7 +13,7 @@ private const val path = "/aareg-mock"
 fun WireMockServer.stubAareg() : WireMockServer =
     stubHentArbeidsforhold(identitetsnummer = AnythingPattern(), response = defaultResponse)
         .stubHentArbeidsforhold(identitetsnummer = WireMock.equalTo("22222222222"), response = "[]")
-        .stubHentArbeidsforhold(identitetsnummer = WireMock.equalTo("22053826656"), response = flereArbeidsforholdIar, inkluderAvsluttetArbeidsforhold = true)
+        .stubHentArbeidsforhold(identitetsnummer = WireMock.equalTo("11410183759"), response = flereArbeidsforholdIar, inkluderAvsluttetArbeidsforhold = true)
 
 fun WireMockServer.getAaregBaseUrl() = baseUrl() + path
 

--- a/src/test/kotlin/no/nav/k9punsj/wiremock/SafMocks.kt
+++ b/src/test/kotlin/no/nav/k9punsj/wiremock/SafMocks.kt
@@ -262,7 +262,7 @@ object SafMockResponses {
           ],
           "bruker": {
             "type": "FNR",
-            "id": "29099000129"
+            "id": "24420167209"
           },
           "sak": {
             "fagsakId": "$fagsakId",
@@ -296,7 +296,7 @@ object SafMockResponses {
             }
           ],
           "avsenderMottaker": {
-            "id": "29099000129",
+            "id": "24420167209",
             "type": "FNR"
           }
         }
@@ -347,7 +347,7 @@ object SafMockResponses {
           ],
           "bruker": {
             "type": "FNR",
-            "id": "29099000129"
+            "id": "24420167209"
           },
           "dokumenter": [
             {

--- a/src/test/resources/oms-ut/søknad-fra-frontend-trekk-kompleks.json
+++ b/src/test/resources/oms-ut/søknad-fra-frontend-trekk-kompleks.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "ac55de59-56c3-483d-9f65-f2a683cb6426",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "mottattDato": "2021-11-02",
   "klokkeslett": "12:53",
   "journalposter": [

--- a/src/test/resources/oms-ut/søknad-fra-frontend-trekk.json
+++ b/src/test/resources/oms-ut/søknad-fra-frontend-trekk.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "ac55de59-56c3-483d-9f65-f2a683cb6426",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "mottattDato": "2021-11-02",
   "klokkeslett": "12:53",
   "journalposter": [

--- a/src/test/resources/oms/søknad-fra-frontend-trekk-kompleks.json
+++ b/src/test/resources/oms/søknad-fra-frontend-trekk-kompleks.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "ac55de59-56c3-483d-9f65-f2a683cb6426",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "mottattDato": "2021-11-02",
   "klokkeslett": "12:53",
   "journalposter": [

--- a/src/test/resources/oms/søknad-fra-frontend-trekk.json
+++ b/src/test/resources/oms/søknad-fra-frontend-trekk.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "ac55de59-56c3-483d-9f65-f2a683cb6426",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "mottattDato": "2021-11-02",
   "klokkeslett": "12:53",
   "journalposter": [

--- a/src/test/resources/psb/ferie-null-søknad.json
+++ b/src/test/resources/psb/ferie-null-søknad.json
@@ -1,13 +1,13 @@
 {
   "soeknadId": "c5040ae4-6c33-4a40-a8a7-a8ad97406f3b",
-  "soekerId": "15026819005",
+  "soekerId": "24420167209",
   "journalposter": [
     "7523521"
   ],
   "mottattDato": "2021-05-10",
   "klokkeslett": "12:53",
   "barn": {
-    "norskIdent": "15026819005"
+    "norskIdent": "24420167209"
   },
   "sendtInn": false,
   "erFraK9": false,
@@ -36,7 +36,7 @@
           ]
         },
         "organisasjonsnummer": null,
-        "norskIdent": "15026819005"
+        "norskIdent": "24420167209"
       }
     ],
     "frilanserArbeidstidInfo": null,

--- a/src/test/resources/psb/ferie-søknad.json
+++ b/src/test/resources/psb/ferie-søknad.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "7e423055-9a46-469f-b17b-8dcfb3ca305c",
-  "soekerId": "02068519929",
+  "soekerId": "14430175875",
   "journalposter": [
     "493344609"
   ],

--- a/src/test/resources/psb/ignorer-opptjening-endringssøknad.json
+++ b/src/test/resources/psb/ignorer-opptjening-endringssøknad.json
@@ -3,12 +3,12 @@
   "versjon": "1.0.0",
   "mottattDato": "",
   "soeker": {
-    "norskIdentitetsnummer": "20018409020"
+    "norskIdentitetsnummer": "14430175875"
   },
   "ytelse": {
     "type": "PLEIEPENGER_SYKT_BARN",
     "barn": {
-      "norskIdentitetsnummer": "24041255877",
+      "norskIdentitetsnummer": "14510058187",
       "foedselsdato": null
     },
     "soeknadsperiode": [],

--- a/src/test/resources/psb/land_tom_string.json
+++ b/src/test/resources/psb/land_tom_string.json
@@ -1,13 +1,13 @@
 {
   "soeknadId": "1f3fe1c2-9e11-47d0-a279-7cf674108bbf",
-  "soekerId": "24126622895",
+  "soekerId": "17420373147",
   "journalposter": [
     "7523521"
   ],
   "mottattDato": "2021-05-11",
   "klokkeslett": "12:53",
   "barn": {
-    "norskIdent": "11020777569",
+    "norskIdent": "17420373147",
     "foedselsdato": null
   },
   "sendtInn": false,

--- a/src/test/resources/psb/med-tid-søknad.json
+++ b/src/test/resources/psb/med-tid-søknad.json
@@ -1,6 +1,6 @@
 {
   "soeknadId": "54dc7996-907e-4a98-8c99-ee2c68df74fc",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "journalposter": [
     "200"
   ],
@@ -27,7 +27,7 @@
   "arbeidstid": {
     "arbeidstakerList": [
       {
-        "norskIdent": "24058120878",
+        "norskIdent": "13480175462",
         "organisasjonsnummer": null,
         "arbeidstidInfo": {
           "perioder": [

--- a/src/test/resources/psb/uten-uttak-søknad.json
+++ b/src/test/resources/psb/uten-uttak-søknad.json
@@ -1,13 +1,13 @@
 {
   "soeknadId": "5cf03cbd-a9c0-402b-adb4-c9219e00fd44",
-  "soekerId": "29099000129",
+  "soekerId": "24420167209",
   "journalposter": [
     "7523521"
   ],
   "mottattDato": "2021-05-04",
   "klokkeslett": "12:53",
   "barn": {
-    "norskIdent": "29099000129",
+    "norskIdent": "24420167209",
     "foedselsdato": ""
   },
   "sendtInn": false,
@@ -37,7 +37,7 @@
           ]
         },
         "organisasjonsnummer": null,
-        "norskIdent": "29099000129"
+        "norskIdent": "24420167209"
       }
     ]
   },


### PR DESCRIPTION
Erstatter fiktive fødselsnummer i testkode med syntetiske personnummer (syntetiske personnummer) som ikke matcher ekte personer.