### PR TITLE
Handter "ikke stottet journalpost" som konflikt

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/CoroutineRequestContext.kt
+++ b/src/main/kotlin/no/nav/k9punsj/CoroutineRequestContext.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext
 import net.logstash.logback.argument.StructuredArguments.e
 import no.nav.k9punsj.felles.IkkeFunnet
+import no.nav.k9punsj.felles.IkkeStøttetJournalpost
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.token.IdToken
 import no.nav.security.token.support.core.jwt.JwtToken
@@ -112,6 +113,12 @@ private fun Routes(
         ServerResponse
             .notFound()
             .buildAndAwait()
+    }
+    onError<IkkeStøttetJournalpost> { _, _ ->
+        ServerResponse
+            .status(HttpStatus.CONFLICT)
+            .json()
+            .bodyValueAndAwait("""{"type":"punsj://ikke-støttet-journalpost"}""")
     }
     onError<DecodingException> { error, serverRequest ->
         val exceptionId = ULID().nextValue().toString()

--- a/src/test/kotlin/no/nav/k9punsj/gosys/GosysRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/gosys/GosysRoutesTest.kt
@@ -4,10 +4,13 @@ import no.nav.helse.dusseldorf.testsupport.jws.Azure
 import no.nav.k9punsj.AbstractContainerBaseTest
 import no.nav.k9punsj.integrasjoner.gosys.Gjelder
 import no.nav.k9punsj.wiremock.JournalpostIds
+import no.nav.k9punsj.wiremock.SafMockResponses
 import no.nav.k9punsj.wiremock.saksbehandlerAccessToken
+import no.nav.k9punsj.wiremock.stubSafHenteJournalpost
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
 
@@ -61,5 +64,35 @@ internal class GosysRoutesTest: AbstractContainerBaseTest() {
             .body(BodyInserters.fromValue(body))
             .exchange()
             .expectStatus().isOk
+    }
+
+    @Test
+    fun `ikke støttet journalpost håndteres som conflict`() {
+        val journalpostId = "123"
+        wireMockServer.stubSafHenteJournalpost(
+            journalpostId = journalpostId,
+            responseBody = SafMockResponses.OkResponseHenteJournalpost(journalpostId = journalpostId, tema = "SYK")
+        )
+
+        @Language("JSON")
+        val body = """
+        {
+          "journalpostId": "$journalpostId",
+          "norskIdent": "24420167209"
+        }
+        """.trimIndent()
+
+        webTestClient.post()
+            .uri { it.path("/api/gosys/opprettJournalforingsoppgave/").build() }
+            .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BodyInserters.fromValue(body))
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.CONFLICT)
+            .expectBody().json(
+                """
+                    {"type":"punsj://ikke-støttet-journalpost"}
+                """.trimIndent()
+            )
     }
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**

`IkkeStøttetJournalpost` er en forventet domenehendelse når Punsj ikke støtter journalposten.

I noen ruter ble denne feilen ikke fanget lokalt. Da gikk den videre til felles `Throwable`-håndtering og ble logget som ukjent feil med stacktrace, selv om SAF allerede logger forventet årsak som `warn`.

### **Løsning**

La til felles håndtering av `IkkeStøttetJournalpost`.
Feilen returnerer nå HTTP 409 med eksisterende frontend-kontrakt: `{"type":"punsj://ikke-støttet-journalpost"}`
Dette beholder `warn` fra SAF, men hindrer at forventet domenehendelse logges som `error`.

### **Andre endringer**
La til regresjonstest for Gosys-ruten, som tidligere ikke fanget `IkkeStøttetJournalpost` lokalt.