### PR TITLE
chore: GitHub governance-oppsett

### DIFF
--- a/.github/instructions/governance-review-okonomi.instructions.md
+++ b/.github/instructions/governance-review-okonomi.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Økonomireglementet — spesielle hensyn
+
+Kodebasen forvalter ytelser/utbetalinger underlagt økonomireglementet. Flagg for menneskelig reviewer.
+
+## Uhensiktsmessig spesialbehandling
+Logikk som behandler enkeltpersoner/organisasjoner/saker ulikt uten saklig grunnlag: hardkodede aktørId, FNR, saksnummer, orgnummer i forretningslogikk. Unntak: testdata, midlertidige filtre med kommentar + oppfølgingssak.
+
+## Flyway-migrasjoner (økonomisk data)
+Tabeller med finansielle data (ytelse, beregning, oppdrag, tilbakekreving, vedtak, utbetaling, refusjon). Destruktive migrasjoner (DROP TABLE/COLUMN, ALTER type). Feil versjonsnummerering. Endring av beregningsgrunnlag/satser/vedtaksdata.
+
+## Sporbarhet
+PR-beskrivelse skal inneholde lenke (Jira, issue, Slack) eller tydelig **hvorfor**. Forretningslogikk uten sporbar begrunnelse → flagg.
+
+## Rimelighet
+Rimelig omfang vs. beskrevet behov. Utilsiktede sideeffekter på beregning/utbetaling. Feilhåndteringsendringer som kan føre til feilutbetalinger/tapte krav.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,11 @@
 
 ### Andre endringer
 
+
+---
+
+### Sjekkliste for godkjenner
+
+- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
+- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
+- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres


### PR DESCRIPTION
Standardiserer governance-filer på tvers av teamets repoer for å sikre konsistent CODEOWNERS, review-instruksjoner, PR-mal og eventuelle labels.

Filene vedlikeholdes sentralt i [sif-team/governance](https://github.com/navikt/sif-team/tree/main/governance) og distribueres med `distribute_files.sh`.