### PR TITLE
markere historiske saker og kunne sjekke tilgang til historiske på token

### DIFF
--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -23,6 +23,8 @@ spec:
           - id: "93e8903d-5c3f-4cbe-929e-0afeb22dec73"
           # 0000-GA-k9-veileder
           - id: "5bc5cae2-3ef9-4897-9828-766757299de8"
+          # 0000-GA-k9-historisk-sak
+          - id: "f92e7578-b530-4e0f-87e6-f5f82fa84168"
       singlePageApplication: true
       replyURLs:
         - https://k9-punsj.intern.dev.nav.no/internal/swagger-ui/oauth2-redirect.html
@@ -125,6 +127,9 @@ spec:
     # 0000-GA-k9-saksbehandler
     - name: BRUKER_GRUPPE_ID_SAKSBEHANDLER
       value: "93e8903d-5c3f-4cbe-929e-0afeb22dec73"
+    # 0000-GA-k9-historisk-sak
+    - name: BRUKER_GRUPPE_ID_HISTORISK_SAK
+      value: "f92e7578-b530-4e0f-87e6-f5f82fa84168"
 
     # Audit logging
     - name: AUDITLOGGER_ENABLED

--- a/deploy/prod-fss.yml
+++ b/deploy/prod-fss.yml
@@ -23,6 +23,8 @@ spec:
           - id: "466d0df7-22ba-4c68-b848-73478cfd0486"
           # 0000-GA-k9-veileder
           - id: "be11a922-59a2-4afa-b5ad-b9e9bd445268"
+          # 0000-GA-k9-historisk-sak
+          - id: "dbd1fce4-6e0a-4fa6-8e9b-e99d1c239c72"
       singlePageApplication: true
       replyURLs:
         - https://k9-punsj.intern.nav.no/internal/swagger-ui/oauth2-redirect.html
@@ -123,6 +125,9 @@ spec:
     # 0000-GA-k9-saksbehandler
     - name: BRUKER_GRUPPE_ID_SAKSBEHANDLER
       value: "466d0df7-22ba-4c68-b848-73478cfd0486"
+    # 0000-GA-k9-historisk-sak
+    - name: BRUKER_GRUPPE_ID_HISTORISK_SAK
+      value: "dbd1fce4-6e0a-4fa6-8e9b-e99d1c239c72"
 
     # Audit logging
     - name: AUDITLOGGER_ENABLED

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -12,6 +12,7 @@ import no.nav.fpsak.tidsserie.LocalDateSegment
 import no.nav.fpsak.tidsserie.LocalDateTimeline
 import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
 import no.nav.helse.dusseldorf.oauth2.client.CachedAccessTokenClient
+import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType
 import no.nav.k9.kodeverk.dokument.Brevkode
 import no.nav.k9.sak.kontrakt.arbeidsforhold.InntektArbeidYtelseArbeidsforholdV2Dto
@@ -806,12 +807,15 @@ class K9SakServiceImpl(
                 val fagsakYtelseType = FagsakYtelseType.fraKode(sakstypeKode)
                 val gyldigPeriode: JSONObject? = it.optJSONObject("gyldigPeriode")
                 val periodeDto: PeriodeDto? = gyldigPeriode?.somPeriodeDto()
+                val statusKode = it.optJSONObject("status")?.optString("kode")
+                    ?: it.optString("status").takeIf { s -> s.isNotEmpty() }
                 Fagsak(
                     saksnummer = saksnummer,
                     sakstype = fagsakYtelseType,
                     pleietrengendeAktorId = pleietrengende,
                     gyldigPeriode = periodeDto,
-                    relatertPersonAktørId = relatertPersonAktorId
+                    relatertPersonAktørId = relatertPersonAktorId,
+                    status = statusKode?.let { kode -> FagsakStatus.fraKode(kode) },
                 )
             }.toSet()
 

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -808,7 +808,6 @@ class K9SakServiceImpl(
                 val gyldigPeriode: JSONObject? = it.optJSONObject("gyldigPeriode")
                 val periodeDto: PeriodeDto? = gyldigPeriode?.somPeriodeDto()
                 val statusKode = it.optJSONObject("status")?.optString("kode")
-                    ?: it.optString("status").takeIf { s -> s.isNotEmpty() }
                 Fagsak(
                     saksnummer = saksnummer,
                     sakstype = fagsakYtelseType,

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/dto/Fagsak.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/dto/Fagsak.kt
@@ -1,5 +1,6 @@
 package no.nav.k9punsj.integrasjoner.k9sak.dto
 
+import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType
 import no.nav.k9punsj.felles.dto.PeriodeDto
 
@@ -8,5 +9,6 @@ data class Fagsak(
     val sakstype: FagsakYtelseType,
     val pleietrengendeAktorId: String?,
     val relatertPersonAktørId: String?,
-    val gyldigPeriode: PeriodeDto?
+    val gyldigPeriode: PeriodeDto?,
+    val status: FagsakStatus? = null,
 )

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
@@ -73,7 +73,8 @@ class SakService(
                     gyldigPeriode = null,
                     relatertPersonIdent = relatertPerson?.identitetsnummer,
                     relatertPerson = relatertPerson,
-                    behandlingsår = it.behandlingsår
+                    behandlingsår = it.behandlingsår,
+                    historisk = false
                 )
             }
             // Returnerer fagsaker og reserverte saksnummere

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
@@ -1,5 +1,6 @@
 package no.nav.k9punsj.sak
 
+import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9punsj.domenetjenester.PersonService
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
@@ -39,6 +40,7 @@ class SakService(
                 }
 
                 val gyldigPeriode = it.gyldigPeriode
+                val erHistorisk = it.status == FagsakStatus.HISTORISK
                 SakInfoDto(
                     reservert = false,
                     fagsakId = it.saksnummer,
@@ -48,7 +50,8 @@ class SakService(
                     relatertPersonIdent = relatertPersonIdent,
                     relatertPerson = relatertPerson,
                     gyldigPeriode = gyldigPeriode,
-                    behandlingsår = gyldigPeriode?.fom?.year
+                    behandlingsår = gyldigPeriode?.fom?.year,
+                    historisk = erHistorisk,
                 )
             }
             logger.info("Henter reserverte saksnummere fra k9...")

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -3,7 +3,6 @@ package no.nav.k9punsj.sak
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.openapi.OasFeil
-import no.nav.k9punsj.sak.dto.SakInfoDto
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -3,6 +3,7 @@ package no.nav.k9punsj.sak
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.openapi.OasFeil
+import no.nav.k9punsj.sak.dto.SakInfoDto
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
@@ -30,7 +31,6 @@ internal class SakerRoutes(
     internal object Urls {
         internal const val HentSaker = "/saker/hent"
     }
-
 
     @Bean
     fun SakerRoutes() = SaksbehandlerRoutes(authenticationHandler) {

--- a/src/main/kotlin/no/nav/k9punsj/sak/dto/SakInfoDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/dto/SakInfoDto.kt
@@ -13,4 +13,5 @@ data class SakInfoDto(
     val behandlingsår: Int?,
     val relatertPersonIdent: String?,
     val relatertPerson: PdlPerson?,
+    val historisk: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/k9punsj/sak/dto/SakInfoDto.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/dto/SakInfoDto.kt
@@ -13,5 +13,5 @@ data class SakInfoDto(
     val behandlingsår: Int?,
     val relatertPersonIdent: String?,
     val relatertPerson: PdlPerson?,
-    val historisk: Boolean = false,
+    val historisk: Boolean,
 )

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IIdToken.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IIdToken.kt
@@ -7,4 +7,5 @@ interface IIdToken {
     fun erSaksbehandler() :Boolean
     fun erVeileder() :Boolean
     fun harBasistilgang() :Boolean
+    fun harHistoriskTilgang() :Boolean
 }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdToken.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdToken.kt
@@ -18,5 +18,8 @@ data class IdToken(
     override fun erSaksbehandler(): Boolean = jwt.groups.any { s -> s == System.getenv("BRUKER_GRUPPE_ID_SAKSBEHANDLER")!! }
     override fun erVeileder(): Boolean = jwt.groups.any { s -> s == System.getenv("BRUKER_GRUPPE_ID_VEILEDER")!! }
     override fun harBasistilgang(): Boolean = erSaksbehandler() || erVeileder()
+    override fun harHistoriskTilgang(): Boolean = System.getenv("BRUKER_GRUPPE_ID_HISTORISK_SAK")?.let { gruppeId ->
+        jwt.groups.any { s -> s == gruppeId }
+    } ?: false
     override fun getNavIdent(): String = jwt.NAVident
 }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
@@ -9,4 +9,5 @@ data class IdTokenLocal(
     override fun erVeileder(): Boolean = false
     override fun harBasistilgang(): Boolean = true
     override fun getNavIdent(): String = "Z000000"
+    override fun harHistoriskTilgang(): Boolean = true
 }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
@@ -9,5 +9,8 @@ data class IdTokenLocal(
     override fun erVeileder(): Boolean = false
     override fun harBasistilgang(): Boolean = true
     override fun getNavIdent(): String = "Z000000"
-    override fun harHistoriskTilgang(): Boolean = true
+    override fun harHistoriskTilgang(): Boolean = value
+        .takeIf { it.isNotBlank() }
+        ?.let { runCatching { IdToken(it).harHistoriskTilgang() }.getOrDefault(false) }
+        ?: false
 }


### PR DESCRIPTION
### Behov / Bakgrunn

Saker som hentes ut av frontend må markeres med om de er historiske eller ikke. Tilgangsstyring på APIer kommer på egen PR.

### Løsning

- Lagrer og eksponerer fagsak-status slik at frontend kan avgjøre om en sak er historisk.
- Utvider token-kontrakten med `harHistoriskTilgang()`.
- Beregner historisk tilgang fra token-grupper (konfigurert gruppe-id), ikke hardkodet verdi.

### Andre endringer

- Oppdatert lokal token-implementasjon (`IdTokenLocal`) slik at historisk tilgang hentes fra tokeninnhold når token er tilgjengelig, og ellers returnerer `false`.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres