### PR TITLE
debug pdl respons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/sif-baseimages/java-25:2026.06.01.1145Z
+FROM ghcr.io/navikt/sif-baseimages/java-25:2026.06.04.0846Z
 
 LABEL org.opencontainers.image.source=https://github.com/navikt/k9-punsj
 

--- a/deploy/dev-gcp.yml
+++ b/deploy/dev-gcp.yml
@@ -172,6 +172,10 @@ spec:
     - name: SETT_PAA_VENT_TID
       value: "PT1H"
 
+    # Logging
+    - name: LOGGING_LEVEL_NO_NAV_K9PUNSJ_INTEGRASJONER_PDL
+      value: "DEBUG"
+
     # Feature toggles
     - name: FERDIGSTILL_GOSYSOPPGAVE_ENABLED
       value: "true"

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/pdl/PdlServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/pdl/PdlServiceImpl.kt
@@ -193,6 +193,8 @@ class PdlServiceImpl(
             logger.warn("Errors i response fra PDL. Errors=${objectMapper().writeValueAsString(errors)}")
         }
 
+        logger.debug("PDL rårespons: {}", response)
+
         return response
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Får en rar feil med oppslag på en journalpost, hvor vi mangler navn i pdl-responsen. Så har lyst til å se hvordan den responsen ser ut. Ser ikke ut til å kastes noen feil

skal kun enable debug-logging i Q på pakkenivå NO_NAV_K9PUNSJ_INTEGRASJONER_PDL
https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.log-levels
---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
