### PR TITLE
eksponere tilganger i token til frontend

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/UserRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/UserRoutes.kt
@@ -1,0 +1,44 @@
+package no.nav.k9punsj.tilgangskontroll
+
+import no.nav.k9punsj.RequestContext
+import no.nav.k9punsj.SaksbehandlerRoutes
+import no.nav.k9punsj.idToken
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import kotlin.coroutines.coroutineContext
+
+internal data class UserDto(
+    val name: String,
+    val erSaksbehandler: Boolean,
+    val erVeileder: Boolean,
+    val harBasistilgang: Boolean,
+    val harHistoriskTilgang: Boolean,
+)
+
+@Configuration
+internal class UserRoutes(
+    private val authenticationHandler: AuthenticationHandler,
+) {
+    @Bean
+    fun UserRoutes() = SaksbehandlerRoutes(authenticationHandler) {
+        GET("/api/user") { request ->
+            RequestContext(coroutineContext, request) {
+                val token = coroutineContext.idToken()
+                ServerResponse.ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValueAndAwait(
+                        UserDto(
+                            name = token.getName(),
+                            erSaksbehandler = token.erSaksbehandler(),
+                            erVeileder = token.erVeileder(),
+                            harBasistilgang = token.harBasistilgang(),
+                            harHistoriskTilgang = token.harHistoriskTilgang(),
+                        )
+                    )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IIdToken.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IIdToken.kt
@@ -4,6 +4,7 @@ interface IIdToken {
     val value: String
     val jwt: JWTToken?
     fun getNavIdent(): String
+    fun getName(): String
     fun erSaksbehandler() :Boolean
     fun erVeileder() :Boolean
     fun harBasistilgang() :Boolean

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdToken.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdToken.kt
@@ -22,4 +22,5 @@ data class IdToken(
         jwt.groups.any { s -> s == gruppeId }
     } ?: false
     override fun getNavIdent(): String = jwt.NAVident
+    override fun getName(): String = jwt.name ?: jwt.NAVident
 }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/IdTokenLocal.kt
@@ -9,6 +9,7 @@ data class IdTokenLocal(
     override fun erVeileder(): Boolean = false
     override fun harBasistilgang(): Boolean = true
     override fun getNavIdent(): String = "Z000000"
+    override fun getName(): String = "Lokal Saksbehandler"
     override fun harHistoriskTilgang(): Boolean = value
         .takeIf { it.isNotBlank() }
         ?.let { runCatching { IdToken(it).harHistoriskTilgang() }.getOrDefault(false) }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/JWTToken.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/token/JWTToken.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class JWTToken(
     val NAVident : String, // Z994048
+    val name: String? = null, // Visningsnavn fra Azure AD
     val aud: String, // 5afad323-c9df-4e14-b481-b278e9d2bf69
     val azp: String, // a084abb8-6a38-4506-84c2-e4ac8b438a05
     val exp: Int, // 1586930888


### PR DESCRIPTION
### Behov / Bakgrunn
Frontend har behov for å vite om saksbehandler har tilgang til historiske saker, slik at kun saksbehandlere med tilgangen får lov til å velge disse fagsakene sakene i brukergrensesnittet. 

Erstatter /me i backend for frontend, som kun returnerer navn på innlogget bruker

### Løsning
Eksponerer tilgangene som finnes på tokenet

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
