### PR TITLE
Tilgangskontroll på historiske saker

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/felles/Feil.kt
+++ b/src/main/kotlin/no/nav/k9punsj/felles/Feil.kt
@@ -7,7 +7,13 @@ import java.net.URI
 
 internal class IkkeStøttetJournalpost(feil: String = "Punsj støtter ikke denne journalposten.") : Throwable(feil)
 internal class NotatUnderArbeidFeil : Throwable("Notatet må ferdigstilles før det kan åpnes i Punsj")
-internal class IkkeTilgang(feil: String) : Throwable(feil)
+internal class IkkeTilgang(val feil: String) : Throwable(feil) {
+    companion object {
+        fun historiskSak(fagsakId: String) = IkkeTilgang(
+            "Fagsak $fagsakId er historisk, og brukeren har ikke tilgang til historiske saker."
+        )
+    }
+}
 internal class FeilIAksjonslogg(feil: String) : Throwable(feil)
 internal class UgyldigToken(feil: String) : Throwable(feil)
 internal class IkkeFunnet : Throwable()

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
@@ -143,16 +143,14 @@ internal class JournalpostRoutes(
                         }
                     }
 
-
                     if (k9Fagsak != null && k9Fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
-                        throw IkkeTilgang("Bruker har ikke tilgang til historiske saker")
+                        throw IkkeTilgang("Fagsak ${k9Fagsak.fagsakId} er historisk, og brukeren har ikke tilgang til historiske saker.")
                     }
 
                     val utledetSak =
                         utledSak(
                             erFerdigstiltEllerJournalfoert,
-                            safSak,
-                            k9Fagsak,
+                            safSak, k9Fagsak,
                             k9PunsjFagsakYtelseType,
                             punsjJournalpost
                         )

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
@@ -16,6 +16,7 @@ import no.nav.k9punsj.felles.IkkeTilgang
 import no.nav.k9punsj.felles.JournalpostId.Companion.somJournalpostId
 import no.nav.k9punsj.felles.PunsjFagsakYtelseType
 import no.nav.k9punsj.fordel.K9FordelType
+import no.nav.k9punsj.idToken
 import no.nav.k9punsj.integrasjoner.dokarkiv.SafDtos
 import no.nav.k9punsj.integrasjoner.gosys.GosysService
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
@@ -140,6 +141,11 @@ internal class JournalpostRoutes(
                                 .filterNot { it.reservert }
                                 .firstOrNull { it.fagsakId == sak.fagsakId }
                         }
+                    }
+
+
+                    if (k9Fagsak != null && k9Fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
+                        throw IkkeTilgang("Bruker har ikke tilgang til historiske saker")
                     }
 
                     val utledetSak =

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutes.kt
@@ -144,7 +144,7 @@ internal class JournalpostRoutes(
                     }
 
                     if (k9Fagsak != null && k9Fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
-                        throw IkkeTilgang("Fagsak ${k9Fagsak.fagsakId} er historisk, og brukeren har ikke tilgang til historiske saker.")
+                        throw IkkeTilgang.historiskSak(k9Fagsak.fagsakId)
                     }
 
                     val utledetSak =
@@ -190,7 +190,7 @@ internal class JournalpostRoutes(
                 } catch (case: IkkeTilgang) {
                     return@RequestContext ServerResponse
                         .status(HttpStatus.FORBIDDEN)
-                        .buildAndAwait()
+                        .bodyValueAndAwait(case.feil)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRoutes.kt
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.BodyExtractors
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.bodyValueAndAwait
-import org.springframework.web.reactive.function.server.buildAndAwait
 import kotlin.coroutines.coroutineContext
 
 @Configuration

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRoutes.kt
@@ -3,14 +3,17 @@ package no.nav.k9punsj.journalpost.postmottak
 import kotlinx.coroutines.reactive.awaitFirst
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
+import no.nav.k9punsj.felles.IkkeTilgang
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.BodyExtractors
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.buildAndAwait
 import kotlin.coroutines.coroutineContext
 
 @Configuration
@@ -35,7 +38,14 @@ internal class PostMottakRoutes(
                 )?.let { return@RequestContext it }
 
                 val dto = request.body(BodyExtractors.toMono(JournalpostMottaksHaandteringDto::class.java)).awaitFirst()
-                val saksnummerDto= postMottakService.klassifiserOgJournalfør(dto)
+
+                val saksnummerDto = try {
+                    postMottakService.klassifiserOgJournalfør(dto)
+                } catch (case: IkkeTilgang) {
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.FORBIDDEN)
+                        .bodyValueAndAwait(case.feil)
+                }
 
                 return@RequestContext ServerResponse.ok().bodyValueAndAwait(saksnummerDto)
             }

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
@@ -1,6 +1,5 @@
 package no.nav.k9punsj.journalpost.postmottak
 
-import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType
 import no.nav.k9.sak.typer.AktørId
 import no.nav.k9punsj.akjonspunkter.AksjonspunktKode

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
@@ -1,5 +1,6 @@
 package no.nav.k9punsj.journalpost.postmottak
 
+import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType
 import no.nav.k9.sak.typer.AktørId
 import no.nav.k9punsj.akjonspunkter.AksjonspunktKode
@@ -103,10 +104,8 @@ class PostMottakService(
             reservertSaksnummerDto.saksnummer
         } else {
             val fagsak = sakService.hentSaker(brukerIdent).firstOrNull { it.fagsakId == eksisterendeSaksnummer }
-            if (fagsak?.historisk == true && !coroutineContext.idToken().harHistoriskTilgang()) {
-                throw IkkeTilgang(
-                    "Fagsak $eksisterendeSaksnummer er historisk, og brukeren har ikke tilgang til historiske saker."
-                )
+            if (fagsak != null && fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
+                throw IkkeTilgang.historiskSak(fagsak.fagsakId)
             }
             logger.info("Bruker eksisterende saksnummer: $eksisterendeSaksnummer")
             eksisterendeSaksnummer

--- a/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakService.kt
@@ -6,7 +6,9 @@ import no.nav.k9punsj.akjonspunkter.AksjonspunktKode
 import no.nav.k9punsj.akjonspunkter.AksjonspunktService
 import no.nav.k9punsj.akjonspunkter.AksjonspunktStatus
 import no.nav.k9punsj.domenetjenester.PersonService
+import no.nav.k9punsj.felles.IkkeTilgang
 import no.nav.k9punsj.felles.dto.SaksnummerDto
+import no.nav.k9punsj.idToken
 import no.nav.k9punsj.integrasjoner.dokarkiv.SafDtos
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
@@ -14,17 +16,20 @@ import no.nav.k9punsj.integrasjoner.pdl.PdlService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.journalpost.dto.JournalpostInfo
 import no.nav.k9punsj.journalpost.dto.PunsjJournalpost
+import no.nav.k9punsj.sak.SakService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import kotlin.coroutines.coroutineContext
 
 @Service
 class PostMottakService(
     private val journalpostService: JournalpostService,
     private val pdlService: PdlService,
     private val k9SakService: K9SakService,
+    private val sakService: SakService,
     private val aksjonspunktService: AksjonspunktService,
     private val personService: PersonService,
     @Value("\${ENABLE_SAK_SPLITT_PSB:false}") private val enableSakSplittPSB: Boolean
@@ -97,6 +102,12 @@ class PostMottakService(
 
             reservertSaksnummerDto.saksnummer
         } else {
+            val fagsak = sakService.hentSaker(brukerIdent).firstOrNull { it.fagsakId == eksisterendeSaksnummer }
+            if (fagsak?.historisk == true && !coroutineContext.idToken().harHistoriskTilgang()) {
+                throw IkkeTilgang(
+                    "Fagsak $eksisterendeSaksnummer er historisk, og brukeren har ikke tilgang til historiske saker."
+                )
+            }
             logger.info("Bruker eksisterende saksnummer: $eksisterendeSaksnummer")
             eksisterendeSaksnummer
         }

--- a/src/main/kotlin/no/nav/k9punsj/notat/NotatRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/notat/NotatRoutes.kt
@@ -1,6 +1,7 @@
 package no.nav.k9punsj.notat
 
 import kotlinx.coroutines.reactive.awaitFirst
+import no.nav.k9punsj.felles.IkkeTilgang
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.openapi.OasFeil
@@ -52,12 +53,20 @@ internal class NotatRoutes(
                         .json()
                         .bodyValueAndAwait(it)
                 },
-                onFailure = {
-                    logger.error("Feilet med å opprette notat.", it)
-                    ServerResponse
-                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .json()
-                        .bodyValueAndAwait(OasFeil(it.message))
+                onFailure = { cause ->
+                    when (cause) {
+                        is IkkeTilgang -> ServerResponse
+                            .status(HttpStatus.FORBIDDEN)
+                            .json()
+                            .bodyValueAndAwait(cause.feil)
+                        else -> {
+                            logger.error("Feilet med å opprette notat.", cause)
+                            ServerResponse
+                                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .json()
+                                .bodyValueAndAwait(OasFeil(cause.message))
+                        }
+                    }
                 }
             )
         }

--- a/src/main/kotlin/no/nav/k9punsj/notat/NotatService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/notat/NotatService.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import no.nav.k9punsj.akjonspunkter.AksjonspunktKode
 import no.nav.k9punsj.akjonspunkter.AksjonspunktService
 import no.nav.k9punsj.akjonspunkter.AksjonspunktStatus
+import no.nav.k9punsj.felles.IkkeTilgang
 import no.nav.k9punsj.fordel.K9FordelType
 import no.nav.k9punsj.hentCorrelationId
+import no.nav.k9punsj.idToken
 import no.nav.k9punsj.integrasjoner.dokarkiv.DokumentKategori
 import no.nav.k9punsj.integrasjoner.dokarkiv.FagsakSystem
 import no.nav.k9punsj.integrasjoner.dokarkiv.JournalPostRequest
@@ -53,6 +55,9 @@ class NotatService(
             .firstOrNull { it.fagsakId == notat.fagsakId }
             ?: throw IllegalStateException("Finner ikke fagsak ${notat.fagsakId} for søker ${notat.søkerIdentitetsnummer}")
 
+        if (fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
+            throw IkkeTilgang("Fagsak ${fagsak.fagsakId} er historisk, og brukeren har ikke tilgang til historiske saker.")
+        }
 
         logger.info("Genererer PDF for notat med fagsak [${fagsak.sakstype} - ${notat.fagsakId}].")
         val notatPdf =

--- a/src/main/kotlin/no/nav/k9punsj/notat/NotatService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/notat/NotatService.kt
@@ -56,7 +56,7 @@ class NotatService(
             ?: throw IllegalStateException("Finner ikke fagsak ${notat.fagsakId} for søker ${notat.søkerIdentitetsnummer}")
 
         if (fagsak.historisk && !coroutineContext.idToken().harHistoriskTilgang()) {
-            throw IkkeTilgang("Fagsak ${fagsak.fagsakId} er historisk, og brukeren har ikke tilgang til historiske saker.")
+            throw IkkeTilgang.historiskSak(fagsak.fagsakId)
         }
 
         logger.info("Genererer PDF for notat med fagsak [${fagsak.sakstype} - ${notat.fagsakId}].")

--- a/src/test/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutesTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/journalpost/JournalpostRoutesTest.kt
@@ -1,10 +1,14 @@
 package no.nav.k9punsj.journalpost
 
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.coEvery
 import kotlinx.coroutines.runBlocking
 import no.nav.k9punsj.AbstractContainerBaseTest
+import no.nav.k9punsj.felles.dto.PeriodeDto
+import no.nav.k9punsj.sak.SakService
+import no.nav.k9punsj.sak.dto.SakInfoDto
 import no.nav.k9punsj.wiremock.SafMockResponses
 import no.nav.k9punsj.wiremock.stubSafHenteJournalpost
-//import no.nav.k9punsj.wiremock.stubSafHenteJournalpost
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
@@ -12,6 +16,9 @@ class JournalpostRoutesTest: AbstractContainerBaseTest() {
 
     private val api = "api"
     private val journalpostUri = "journalpost"
+
+    @MockkBean
+    private lateinit var sakService: SakService
 
     @Test
     fun `Gitt journalpost med annet tema enn OMS, forvent conflict feil`(): Unit = runBlocking {
@@ -29,6 +36,45 @@ class JournalpostRoutesTest: AbstractContainerBaseTest() {
                     {"type":"punsj://ikke-støttet-journalpost"}
                 """.trimIndent()
             )
+    }
+
+    @Test
+    fun `Gitt journalpost knyttet til historisk sak og bruker uten historisk tilgang, forvent 403`(): Unit = runBlocking {
+        val journalpostId = "321"
+        val fagsakId = "HISTORISK123"
+        val norskIdent = "24420167209"
+
+        wireMockServer.stubSafHenteJournalpost(
+            journalpostId = journalpostId,
+            responseBody = SafMockResponses.OkResponseHenteJournalpost(
+                journalpostId = journalpostId,
+                tema = "OMS",
+                fagsakId = fagsakId
+            )
+        )
+
+        coEvery { sakService.hentSaker(any()) } returns listOf(
+            SakInfoDto(
+                reservert = false,
+                fagsakId = fagsakId,
+                sakstype = "PSB",
+                pleietrengendeIdent = null,
+                pleietrengende = null,
+                gyldigPeriode = PeriodeDto(fom = java.time.LocalDate.of(2020, 1, 1), tom = java.time.LocalDate.of(2020, 12, 31)),
+                behandlingsår = 2020,
+                relatertPersonIdent = null,
+                relatertPerson = null,
+                historisk = true,
+            )
+        )
+
+        webTestClient.get()
+            .uri("/$api/$journalpostUri/$journalpostId")
+            .header("Authorization", saksbehandlerAuthorizationHeader)
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.FORBIDDEN)
+            .expectBody(String::class.java)
+            .isEqualTo("Fagsak $fagsakId er historisk, og brukeren har ikke tilgang til historiske saker.")
     }
 
     private fun gittJournalpostMedTema(journalpostId: String, tema: String) {

--- a/src/test/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRouteTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakRouteTest.kt
@@ -84,6 +84,37 @@ internal class PostMottakRouteTest : AbstractContainerBaseTest() {
             )
     }
 
+    @Test
+    fun `forventer 403 med melding ved forsøk på å knytte journalpost til historisk sak`(): Unit = runBlocking {
+        val journalpostId = IdGenerator.nesteId()
+        val fagsakId = "HISTORISK456"
+
+        coEvery { postMottakService.klassifiserOgJournalfør(any()) } throws
+            no.nav.k9punsj.felles.IkkeTilgang.historiskSak(fagsakId)
+
+        val mottaksHaandteringDto = JournalpostMottaksHaandteringDto(
+            journalpostId = journalpostId,
+            brukerIdent = "123",
+            pleietrengendeIdent = "456",
+            fagsakYtelseTypeKode = PunsjFagsakYtelseType.PLEIEPENGER_SYKT_BARN.kode,
+            saksnummer = fagsakId,
+            relatertPersonIdent = null,
+            barnAktørIder = null
+        )
+
+        webTestClient
+            .post()
+            .uri { it.path("/api/journalpost/mottak").build() }
+            .body(BodyInserters.fromValue(mottaksHaandteringDto))
+            .header(HttpHeaders.AUTHORIZATION, saksbehandlerAuthorizationHeader)
+            .header("X-Nav-NorskIdent", mottaksHaandteringDto.pleietrengendeIdent!!)
+            .header(CALL_ID_KEY, UUID.randomUUID().toString())
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.FORBIDDEN)
+            .expectBody(String::class.java)
+            .isEqualTo("Fagsak $fagsakId er historisk, og brukeren har ikke tilgang til historiske saker.")
+    }
+
 
     @ParameterizedTest
     @ValueSource(strings = ["1999", "2101", "null"])

--- a/src/test/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/journalpost/postmottak/PostMottakServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.pdl.PdlService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.journalpost.dto.PunsjJournalpost
+import no.nav.k9punsj.sak.SakService
 import no.nav.k9punsj.util.opprettKafkaStringConsumer
 import org.apache.kafka.clients.consumer.Consumer
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
@@ -46,6 +47,9 @@ class PostMottakServiceTest : AbstractContainerBaseTest() {
 
     @MockkBean
     private lateinit var dokarkivGateway: DokarkivGateway
+
+    @MockkBean
+    private lateinit var sakService: SakService
 
     @Autowired
     private lateinit var journalpostService: JournalpostService
@@ -89,6 +93,8 @@ class PostMottakServiceTest : AbstractContainerBaseTest() {
                 )
             ), null
         )
+
+        coEvery { sakService.hentSaker(brukerIdent) } returns emptyList()
 
         coEvery { safGateway.hentJournalpostInfo(journalpostId) } returns opprettSafJournalpost(
             journalpostId,

--- a/src/test/kotlin/no/nav/k9punsj/wiremock/AccessTokenMocks.kt
+++ b/src/test/kotlin/no/nav/k9punsj/wiremock/AccessTokenMocks.kt
@@ -50,7 +50,12 @@ fun Azure.V2_0.saksbehandlerAccessToken() = generateJwt(
         clientId = "k9-punsj-frontend-oidc-auth-proxy",
         audience = "k9-punsj",
         overridingClaims = mapOf(
-                "sub" to "k9-punsj-frontend-oidc-auth-proxy"
+                "sub" to "k9-punsj-frontend-oidc-auth-proxy",
+                "NAVident" to "Z000000",
+                "oid" to "00000000-0000-0000-0000-000000000000",
+                "scp" to "defaultaccess",
+                "azp" to "k9-punsj-frontend-oidc-auth-proxy",
+                "groups" to emptyList<String>()
         )
 )
 


### PR DESCRIPTION
### Behov / Bakgrunn
Kun saksbehandlere med tilgang til historiske saker skal kunne gjøre operasjoner knyttet til historiske saker.

### Løsning
Legge inn sjekker på om saken er historisk og om saksbehandler har riktig tilgang. 

1. Knytte journalpost til historisk sak i klassifiseringssteget
2. Opprette ny journalpost knyttet til historisk sak
3. Oppslag på journalpost knyttet til historisk sak

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
