### PR TITLE
Fix: Fjern kode som forsøker å tilgjengeliggjøre CC-token til bruker.

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/oidc/OidcRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/oidc/OidcRoutes.kt
@@ -1,13 +1,8 @@
 package no.nav.k9punsj.tilgangskontroll.oidc
 
-import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
-import no.nav.helse.dusseldorf.oauth2.client.CachedAccessTokenClient
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
@@ -17,15 +12,8 @@ import kotlin.coroutines.coroutineContext
 
 @Configuration
 internal class OidcRoutes(
-    private val authenticationHandler: AuthenticationHandler,
-    @Qualifier("azure") accessTokenClient: AccessTokenClient
+    private val authenticationHandler: AuthenticationHandler
 ) {
-    private val cachedAccessTokenClient = CachedAccessTokenClient(accessTokenClient)
-    private val scope: Set<String> = setOf("openid")
-
-    private companion object {
-        private val logger: Logger = LoggerFactory.getLogger(OidcRoutes::class.java)
-    }
 
     internal object Urls {
         internal const val HentNavTokenHeader = "/oidc/hentNavTokenHeader"
@@ -34,19 +22,12 @@ internal class OidcRoutes(
     @Bean
     fun OidcRoutes() = SaksbehandlerRoutes(authenticationHandler) {
         GET("/api${Urls.HentNavTokenHeader}") { request ->
-            var navHeader = "Ikke funnet"
-            try {
-                navHeader = cachedAccessTokenClient.getAccessToken(scope)
-                    .asAuthoriationHeader()
-            } catch (e: IllegalStateException) {
-                logger.warn("", e)
-            }
             RequestContext(coroutineContext, request) {
                 val clientHeader = request.headers().header("Authorization")
                 ServerResponse
                     .ok()
                     .contentType(MediaType.TEXT_PLAIN)
-                    .bodyValueAndAwait(clientHeader[0] + "\n" + navHeader)
+                    .bodyValueAndAwait(clientHeader[0])
             }
         }
     }


### PR DESCRIPTION
### Behov / Bakgrunn
Client credentials token skal ikke tilgjengeliggjøres via REST-tjenester. Det blir ikke tilgjengeliggjort her heller, men det er pga validering av scope som sendes inn.

### Løsning

Fjern kode

### Andre endringer


---

### Sjekkliste for godkjenner

- [x] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [x] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [x] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
