### PR TITLE
Forbedre hastighet på handlebars ved å bruke cache

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/notat/PDFGenerator.kt
+++ b/src/main/kotlin/no/nav/k9punsj/notat/PDFGenerator.kt
@@ -4,6 +4,7 @@ import com.github.jknack.handlebars.Context
 import com.github.jknack.handlebars.Handlebars
 import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Template
+import com.github.jknack.handlebars.cache.HighConcurrencyTemplateCache
 import com.github.jknack.handlebars.context.MapValueResolver
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader
 import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder
@@ -126,6 +127,8 @@ abstract class PDFGenerator<in T> {
             )
 
             infiniteLoops(true)
+
+            with(HighConcurrencyTemplateCache())
         }
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Verdikjedetester for punsj er ustabil pga timeouts fordi HTML+PDF-generering tar lang tid. 

### Løsning

Legg på cache for handlebars, det kan gjøre at generering av HTML før PDF-genereringen er raskere.


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
