### PR TITLE
Tjeneste under /sak/perioder for å hente perioder for sak

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -24,7 +24,7 @@ interface K9SakService {
 
     suspend fun hentPerioderSomFinnesIK9ForSaksnummer(
         saksnummer: String,
-    ): Pair<List<PeriodeDto>?, String?>
+    ): List<PeriodeDto>
 
     suspend fun hentPerioderSomFinnesIK9ForPeriode(
         søker: String,

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -136,28 +136,26 @@ class K9SakServiceImpl(
 
     override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(
         saksnummer: String,
-    ): Pair<List<PeriodeDto>?, String?> {
-        val (json, feil) = kotlin.runCatching {
+    ): List<PeriodeDto> {
+        val json = try {
             httpPost(
                 "",
                 hentPerioderForSakUrl + "?saksnummer=${saksnummer}"
             )
-        }.fold(
-            onSuccess = { Pair(it, null) },
-            onFailure = { return Pair(null, it.message) }
-        )
-        return try {
-            if (json == null) {
-                return Pair(null, feil!!)
-            }
-            val resultat = objectMapper().readValue<List<Periode>>(json)
-            val sammenslåttePerioder =
-                LocalDateTimeline(resultat.map { LocalDateSegment<Unit>(it.fom, it.tom, null) }).compress()
-            val liste =
-                sammenslåttePerioder.toSegments().map { periode -> PeriodeDto(periode.fom, periode.tom) }
-            Pair(liste, null)
         } catch (e: Exception) {
-            Pair(null, "Feilet deserialisering $e")
+            throw RuntimeException(e.message, e)
+        }
+
+        return try {
+            objectMapper()
+                .readValue<List<Periode>>(json)
+                .map { LocalDateSegment<Unit>(it.fom, it.tom, null) }
+                .let(::LocalDateTimeline)
+                .compress()
+                .toSegments()
+                .map { periode -> PeriodeDto(periode.fom, periode.tom) }
+        } catch (e: Exception) {
+            throw RuntimeException("Feilet deserialisering $e", e)
         }
     }
 
@@ -652,7 +650,8 @@ class K9SakServiceImpl(
             .body(body)
             .header(
                 HttpHeaders.ACCEPT to "application/json",
-                HttpHeaders.AUTHORIZATION to cachedAccessTokenClient.getOnBehalfOfAccessToken(k9sakScope, idToken).asAuthoriationHeader(),
+                HttpHeaders.AUTHORIZATION to cachedAccessTokenClient.getOnBehalfOfAccessToken(k9sakScope, idToken)
+                    .asAuthoriationHeader(),
                 HttpHeaders.CONTENT_TYPE to "application/json",
                 "callId" to hentCallId()
             ).awaitStringResponseResult()
@@ -666,7 +665,8 @@ class K9SakServiceImpl(
             .httpGet()
             .header(
                 HttpHeaders.ACCEPT to "application/json",
-                HttpHeaders.AUTHORIZATION to cachedAccessTokenClient.getOnBehalfOfAccessToken(k9sakScope, idToken).asAuthoriationHeader(),
+                HttpHeaders.AUTHORIZATION to cachedAccessTokenClient.getOnBehalfOfAccessToken(k9sakScope, idToken)
+                    .asAuthoriationHeader(),
                 HttpHeaders.CONTENT_TYPE to "application/json",
                 "callId" to hentCallId()
             ).awaitStringResponseResult()

--- a/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/omsorgspengerutbetaling/OmsorgspengerutbetalingRoutes.kt
@@ -122,6 +122,7 @@ internal class OmsorgspengerutbetalingRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sak}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val matchfagsak = request.mapMatchFagsak()

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerRoutes.kt
@@ -111,6 +111,7 @@ internal class OpplaeringspengerRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sak}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val matchfagsak = request.mapMatchFagsak()
@@ -124,6 +125,7 @@ internal class OpplaeringspengerRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sakMedSaksnummer}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val saksnummer = request.queryParam("saksnummer").orElseThrow()

--- a/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/opplaeringspenger/OpplaeringspengerService.kt
@@ -11,13 +11,7 @@ import no.nav.k9punsj.domenetjenester.MappeService
 import no.nav.k9punsj.domenetjenester.PersonService
 import no.nav.k9punsj.domenetjenester.SoknadService
 import no.nav.k9punsj.felles.PunsjFagsakYtelseType
-import no.nav.k9punsj.felles.dto.JournalposterDto
-import no.nav.k9punsj.felles.dto.Matchfagsak
-import no.nav.k9punsj.felles.dto.OpprettNySøknad
-import no.nav.k9punsj.felles.dto.PeriodeDto
-import no.nav.k9punsj.felles.dto.SendSøknad
-import no.nav.k9punsj.felles.dto.SøknadFeil
-import no.nav.k9punsj.felles.dto.hentUtJournalposter
+import no.nav.k9punsj.felles.dto.*
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.journalpost.JournalpostService
 import no.nav.k9punsj.openapi.OasFeil
@@ -26,11 +20,7 @@ import no.nav.k9punsj.utils.ServerRequestUtils.søknadLocationUri
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.bodyValueAndAwait
-import org.springframework.web.reactive.function.server.buildAndAwait
-import org.springframework.web.reactive.function.server.json
+import org.springframework.web.reactive.function.server.*
 
 @Service
 internal class OpplaeringspengerService(
@@ -111,7 +101,7 @@ internal class OpplaeringspengerService(
 
         try {
             val søknad: OpplaeringspengerSøknadDto = objectMapper.convertValue(søknadEntitet.søknad!!)
-            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer).first ?: emptyList()
+            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer)
 
             val journalPoster = søknadEntitet.journalposter!!
             val journalposterDto: JournalposterDto = objectMapper.convertValue(journalPoster)
@@ -210,7 +200,7 @@ internal class OpplaeringspengerService(
                 .badRequest()
                 .buildAndAwait()
 
-        val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer).first ?: emptyList()
+        val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer)
         val journalPoster = søknadEntitet.journalposter!!
         val journalposterDto: JournalposterDto = objectMapper.convertValue(journalPoster)
 
@@ -277,9 +267,9 @@ internal class OpplaeringspengerService(
         }
     }
 
-    private suspend fun henterPerioderSomFinnesIK9sak(saksnummer: String?): Pair<List<PeriodeDto>?, String?> {
+    private suspend fun henterPerioderSomFinnesIK9sak(saksnummer: String?): List<PeriodeDto> {
         if (saksnummer.isNullOrBlank()) {
-            return Pair(emptyList(), null)
+            return emptyList()
         }
         return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer)
     }

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseRoutes.kt
@@ -104,6 +104,7 @@ internal class PleiepengerLivetsSluttfaseRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sak}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val matchfagsak = request.mapMatchFagsak()

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnRoutes.kt
@@ -111,6 +111,7 @@ internal class PleiepengerSyktBarnRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sak}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val matchfagsak = request.mapMatchFagsak()
@@ -124,6 +125,7 @@ internal class PleiepengerSyktBarnRoutes(
             }
         }
 
+        //TODO erstattes av /api/saker/perioder
         POST("/api${Urls.HentInfoFraK9sakMedSaksnummer}") { request ->
             RequestContext(currentCoroutineContext(), request) {
                 val saksnummer = request.queryParam("saksnummer").orElseThrow()

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
@@ -273,6 +273,7 @@ internal class PleiepengerSyktBarnService(
         }
     }
 
+    @Deprecated("Bruk tjeneste i SakerRoutes")
     private suspend fun henterPerioderSomFinnesIK9sak(saksnummer: String?): Pair<List<PeriodeDto>?, String?> {
         if (saksnummer.isNullOrBlank()) {
             return Pair(emptyList(), null)

--- a/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnService.kt
@@ -110,7 +110,7 @@ internal class PleiepengerSyktBarnService(
 
         try {
             val søknad: PleiepengerSyktBarnSøknadDto = objectMapper.convertValue(søknadEntitet.søknad!!)
-            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer).first ?: emptyList()
+            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer)
 
             val journalPoster = søknadEntitet.journalposter!!
             val journalposterDto: JournalposterDto = objectMapper.convertValue(journalPoster)
@@ -209,7 +209,7 @@ internal class PleiepengerSyktBarnService(
             )
 
         val (søknad, feilListe) = try {
-            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer).first ?: emptyList()
+            val hentPerioderSomFinnesIK9 = henterPerioderSomFinnesIK9sak(søknadEntitet.k9saksnummer)
             val journalPoster = søknadEntitet.journalposter!!
             val journalposterDto: JournalposterDto = objectMapper.convertValue(journalPoster)
             MapPsbTilK9Format(
@@ -274,9 +274,9 @@ internal class PleiepengerSyktBarnService(
     }
 
     @Deprecated("Bruk tjeneste i SakerRoutes")
-    private suspend fun henterPerioderSomFinnesIK9sak(saksnummer: String?): Pair<List<PeriodeDto>?, String?> {
+    private suspend fun henterPerioderSomFinnesIK9sak(saksnummer: String?): List<PeriodeDto> {
         if (saksnummer.isNullOrBlank()) {
-            return Pair(emptyList(), null)
+            return emptyList()
         }
         return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer)
     }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
@@ -83,7 +83,7 @@ class SakService(
         }
     }
 
-    suspend fun hentPerioderForSaksnummer(saksnummer: String): Pair<List<PeriodeDto>?, String?> {
-        return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer);
+    suspend fun hentPerioderForSaksnummer(saksnummer: String): List<PeriodeDto> {
+        return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer)
     }
 }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
@@ -2,6 +2,7 @@ package no.nav.k9punsj.sak
 
 import no.nav.k9.kodeverk.behandling.FagsakStatus
 import no.nav.k9punsj.domenetjenester.PersonService
+import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.sak.dto.SakInfoDto
@@ -80,5 +81,9 @@ class SakService(
             // Returnerer fagsaker og reserverte saksnummere
             return (fagsaker + reserverteSaksnummere).distinctBy { it.fagsakId }
         }
+    }
+
+    suspend fun hentPerioderForSaksnummer(saksnummer: String): Pair<List<PeriodeDto>?, String?> {
+        return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer);
     }
 }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -3,7 +3,9 @@ package no.nav.k9punsj.sak
 import kotlinx.coroutines.currentCoroutineContext
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
+import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.openapi.OasFeil
+import no.nav.k9punsj.pleiepengersyktbarn.PleiepengerSyktBarnRoutes
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
@@ -29,6 +31,7 @@ internal class SakerRoutes(
 
     internal object Urls {
         internal const val HentSaker = "/saker/hent"
+        internal const val HentPerioder = "/saker/perioder"
     }
 
     @Bean
@@ -53,6 +56,28 @@ internal class SakerRoutes(
                     .status(HttpStatus.OK)
                     .json()
                     .bodyValueAndAwait(saker)
+            }
+        }
+
+        POST("/api${Urls.HentPerioder}") { request ->
+            RequestContext(currentCoroutineContext(), request) {
+                val saksnummer = request.queryParam("saksnummer").orElseThrow()
+
+                //TODO gjør tilgangskontroll eksplisitt her. Tilgangskontroll blir gjort i k9-sak siden det kalles med OBO-token
+
+                val (perioder, _) = sakService.hentPerioderForSaksnummer(saksnummer)
+
+                if (perioder != null) {
+                    ServerResponse
+                        .ok()
+                        .json()
+                        .bodyValueAndAwait(perioder)
+                } else {
+                    ServerResponse
+                        .ok()
+                        .json()
+                        .bodyValueAndAwait(listOf<PeriodeDto>())
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -3,9 +3,7 @@ package no.nav.k9punsj.sak
 import kotlinx.coroutines.currentCoroutineContext
 import no.nav.k9punsj.RequestContext
 import no.nav.k9punsj.SaksbehandlerRoutes
-import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.openapi.OasFeil
-import no.nav.k9punsj.pleiepengersyktbarn.PleiepengerSyktBarnRoutes
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
 import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
@@ -65,19 +63,20 @@ internal class SakerRoutes(
 
                 //TODO gjør tilgangskontroll eksplisitt her. Tilgangskontroll blir gjort i k9-sak siden det kalles med OBO-token
 
-                val (perioder, _) = sakService.hentPerioderForSaksnummer(saksnummer)
-
-                if (perioder != null) {
-                    ServerResponse
-                        .ok()
+                val perioder = try {
+                    sakService.hentPerioderForSaksnummer(saksnummer)
+                } catch (e: Exception) {
+                    logger.error("Feilet med å hente saker.", e)
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .json()
-                        .bodyValueAndAwait(perioder)
-                } else {
-                    ServerResponse
-                        .ok()
-                        .json()
-                        .bodyValueAndAwait(listOf<PeriodeDto>())
+                        .bodyValueAndAwait(OasFeil(e.message))
                 }
+
+                ServerResponse
+                    .ok()
+                    .json()
+                    .bodyValueAndAwait(perioder)
             }
         }
     }

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnSendErrorContractTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnSendErrorContractTest.kt
@@ -44,7 +44,7 @@ internal class PleiepengerSyktBarnSendErrorContractTest : AbstractContainerBaseT
 
         val upstreamDetail = """{"feilmelding":"Det oppstod en serverfeil","feilkode":null,"type":"GENERELL_FEIL"}"""
 
-        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns Pair(emptyList(), null)
+        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns emptyList()
         coEvery { k9SakService.opprettSakOgSendInnSøknad(any(), any(), any(), any(), any(), any()) } throws RestKallException(
             titel = "Restkall mot k9-sak feilet",
             message = upstreamDetail,
@@ -73,7 +73,7 @@ internal class PleiepengerSyktBarnSendErrorContractTest : AbstractContainerBaseT
 
         val upstreamDetail = "Opprettelse av fagsak feilet i k9-sak"
 
-        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns Pair(emptyList(), null)
+        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns emptyList()
         coEvery { k9SakService.opprettSakOgSendInnSøknad(any(), any(), any(), any(), any(), any()) } throws RestKallException(
             titel = "Restkall mot k9-sak feilet",
             message = upstreamDetail,
@@ -102,7 +102,7 @@ internal class PleiepengerSyktBarnSendErrorContractTest : AbstractContainerBaseT
 
         val upstreamDetail = "Konflikt i k9-sak"
 
-        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns Pair(emptyList(), null)
+        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns emptyList()
         coEvery { k9SakService.opprettSakOgSendInnSøknad(any(), any(), any(), any(), any(), any()) } throws RestKallException(
             titel = "Restkall mot k9-sak feilet",
             message = upstreamDetail,

--- a/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnValiderErrorContractTest.kt
+++ b/src/test/kotlin/no/nav/k9punsj/pleiepengersyktbarn/PleiepengerSyktBarnValiderErrorContractTest.kt
@@ -33,7 +33,7 @@ internal class PleiepengerSyktBarnValiderErrorContractTest : AbstractContainerBa
         val correlationId = UUID.randomUUID().toString()
         val norskIdent = "02020050131"
 
-        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns Pair(emptyList(), null)
+        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns emptyList()
 
         val søknad = opprettUtfyltSøknad(
             søknadFraFrontend = LesFraFilUtil.tidSøknad(),
@@ -100,7 +100,7 @@ internal class PleiepengerSyktBarnValiderErrorContractTest : AbstractContainerBa
     fun `PSB valider returnerer 202 for gyldig søknad`(): Unit = runBlocking {
         val norskIdent = "02020050134"
 
-        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns Pair(emptyList(), null)
+        coEvery { k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(any()) } returns emptyList()
 
         val søknad = opprettUtfyltSøknad(
             søknadFraFrontend = LesFraFilUtil.søknadFraFrontend(),

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -13,8 +13,8 @@ import no.nav.k9punsj.felles.dto.SaksnummerDto
 import no.nav.k9punsj.felles.dto.SøknadEntitet
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
-import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.HentK9SaksnummerGrunnlag
+import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import no.nav.k9punsj.util.MockUtil.erFødtI
 import org.springframework.stereotype.Component
@@ -41,8 +41,8 @@ class LokalK9SakService : K9SakService {
         false -> Pair(emptyList(), null)
     }
 
-    override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(saksnummer: String): Pair<List<PeriodeDto>?, String?> {
-        return Pair(emptyList(), null)
+    override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(saksnummer: String): List<PeriodeDto> {
+        return emptyList()
     }
 
     override suspend fun hentPerioderSomFinnesIK9ForPeriode(

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -13,8 +13,8 @@ import no.nav.k9punsj.felles.dto.SøknadEntitet
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakService
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
 import no.nav.k9punsj.integrasjoner.k9sak.dto.HentK9SaksnummerGrunnlag
-import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.ReserverSaksnummerDto
+import no.nav.k9punsj.integrasjoner.k9sak.dto.ReservertSaksnummerDto
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -47,8 +47,8 @@ internal class TestK9SakService : K9SakService {
         return Pair(emptyList(), null)
     }
 
-    override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(saksnummer: String): Pair<List<PeriodeDto>?, String?> {
-        return Pair(emptyList(), null)
+    override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(saksnummer: String): List<PeriodeDto> {
+        return emptyList()
     }
 
     override suspend fun hentPerioderSomFinnesIK9ForPeriode(


### PR DESCRIPTION
### Behov / Bakgrunn

Ønsker å erstatte /k9sak/info med /k9sak/info/saksnummer siden det allerede finnes spesialisert tilgangskontroll for førstnevnte, og frontend skal kunne tilpasses til å gå mot /saksnummer-endepunktene

### Løsning

/k9sak/info/saksnummer er ytelseagnostisk, så lager et nytt slikt endepunkt under /saker/perioder for å indikere det bedre. Metodene den skal erstatte er markert med TODOs

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
