### PR TITLE
Bytter endepunkt for opplæringsinstitusjoner fra k9-sak fra alle til alle-v2

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -98,7 +98,7 @@ class K9SakServiceImpl(
         internal const val hentReservertSaksnummerUrl = "/saksnummer"
         internal const val reserverSaksnummerUrl = "/saksnummer/reserver"
         internal const val hentReserverteSaksnummereUrl = "/saksnummer/søker"
-        internal const val hentInstitusjonerUrl = "/opplæringsinstitusjon/alle"
+        internal const val hentInstitusjonerUrl = "/opplæringsinstitusjon/alle-v2B"
     }
 
     override suspend fun hentPerioderSomFinnesIK9(

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -98,7 +98,7 @@ class K9SakServiceImpl(
         internal const val hentReservertSaksnummerUrl = "/saksnummer"
         internal const val reserverSaksnummerUrl = "/saksnummer/reserver"
         internal const val hentReserverteSaksnummereUrl = "/saksnummer/søker"
-        internal const val hentInstitusjonerUrl = "/opplæringsinstitusjon/alle-v2B"
+        internal const val hentInstitusjonerUrl = "/opplæringsinstitusjon/alle-v2"
     }
 
     override suspend fun hentPerioderSomFinnesIK9(


### PR DESCRIPTION
### Behov / Bakgrunn

Det feiler i prod fordi opplæringsinstitusjoner/alle krever tokenx, men når det kalles fra punsj har vi ikke det tokenet

### Løsning

Bytter til endepunkt som skal ha internt token

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
