### PR TITLE
chore: fjern vault serviceuser-path

### DIFF
--- a/deploy/prod-fss.yml
+++ b/deploy/prod-fss.yml
@@ -81,8 +81,6 @@ spec:
     paths:
       - mountPath: /var/run/secrets/nais.io/vault
         kvPath: /kv/prod/fss/k9-punsj/default
-      - mountPath: /var/run/secrets/nais.io/srvk9punsj
-        kvPath: /serviceuser/data/prod/srvk9punsj
   webproxy: true
   kafka:
     pool: nav-prod


### PR DESCRIPTION
### Behov / Bakgrunn

Som del av migrering bort fra service users til client credentials-flyt fjerner vi Vault serviceuser-paths som ikke lenger er i bruk. Vault-agenten injiserte `SYSTEMBRUKER_USERNAME/PASSWORD` i containeren via init-script, men ingen kode leser disse env-variablene.

### Løsning

- Fjerner `serviceuser`-path fra `deploy/prod-fss.yml`\n- kv-path for `/kv/prod/fss/k9-punsj/default` beholdes (sjekk om aktiv)

`vault.enabled: true` beholdes der det er nødvendig for HikariCPVaultUtil (DB-credentials via `postgresql/`).

### Andre endringer

Ingen.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres