### PR TITLE
Setter cooldown til 0 for å hente teamets eget baseimage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,8 @@ updates:
           - "*"
   - package-ecosystem: docker
     directory: "/"
+    cooldown:
+      #setter cooldown til 0 siden denne bare finner avhengigheter fra teamets egne bygg
+      default-days: 0
     schedule:
       interval: daily


### PR DESCRIPTION
### Behov / Bakgrunn

Dependabot har endret default til 3 dager, men vi ønsker ikke å vente på baseimage vi har bygd selv

### Løsning
Sett cooldown spesifikt til 0 dager for docker

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
