### PR TITLE
TSFF-2458: Endepunkt for manuelt gjenåpne historisk sak

### DIFF
--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakService.kt
@@ -60,4 +60,5 @@ interface K9SakService {
     )
 
     suspend fun hentInstitusjoner(): List<GodkjentOpplæringsinstitusjonDto>
+    suspend fun gjenåpneHistoriskSak(saksnummer: Saksnummer)
 }

--- a/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
+++ b/src/main/kotlin/no/nav/k9punsj/integrasjoner/k9sak/K9SakServiceImpl.kt
@@ -36,6 +36,7 @@ import no.nav.k9punsj.felles.dto.SaksnummerDto
 import no.nav.k9punsj.felles.dto.SøknadEntitet
 import no.nav.k9punsj.hentAuthentication
 import no.nav.k9punsj.hentCallId
+import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.gjenåpneHistoriskSakUrl
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentInstitusjonerUrl
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentIntektsmeldingerUrl
 import no.nav.k9punsj.integrasjoner.k9sak.K9SakServiceImpl.Urls.hentPerioderForSakUrl
@@ -102,6 +103,7 @@ class K9SakServiceImpl(
         internal const val reserverSaksnummerUrl = "/saksnummer/reserver"
         internal const val hentReserverteSaksnummereUrl = "/saksnummer/søker"
         internal const val hentInstitusjonerUrl = "/opplæringsinstitusjon/alle-v2"
+        internal const val gjenåpneHistoriskSakUrl = "/fagsak/gjenapneHistorisk"
     }
 
     override suspend fun hentPerioderSomFinnesIK9ForSaksnummer(
@@ -521,7 +523,21 @@ class K9SakServiceImpl(
                     )
                 }
             )
+    }
 
+    override suspend fun gjenåpneHistoriskSak(saksnummer: Saksnummer) {
+        try {
+            val saksnummerDto = SaksnummerDto(saksnummer.verdi)
+            val body = standardObjectMapper.writeValueAsString(saksnummerDto)
+            httpPost(body, gjenåpneHistoriskSakUrl)
+        } catch (error: Exception) {
+            if (error is RestKallException) {
+                throw error
+            }
+            val feilmelding = "Feil ved gjenåpning av historisk sak i k9-sak"
+            log.error(feilmelding, error)
+            throw IllegalStateException(feilmelding, error)
+        }
     }
 
     private suspend fun utledK9sakPeriode(
@@ -560,7 +576,7 @@ class K9SakServiceImpl(
         }
     }
 
-    private suspend fun K9SakServiceImpl.periodeFraFagsak(
+    private suspend fun periodeFraFagsak(
         søkerIdent: String,
         saksnummer: String,
     ): Periode {

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakService.kt
@@ -1,6 +1,7 @@
 package no.nav.k9punsj.sak
 
 import no.nav.k9.kodeverk.behandling.FagsakStatus
+import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9punsj.domenetjenester.PersonService
 import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.integrasjoner.k9sak.dto.Fagsak
@@ -85,5 +86,9 @@ class SakService(
 
     suspend fun hentPerioderForSaksnummer(saksnummer: String): List<PeriodeDto> {
         return k9SakService.hentPerioderSomFinnesIK9ForSaksnummer(saksnummer)
+    }
+
+    suspend fun gjenåpneHistoriskSak(saksnummer: Saksnummer) {
+        return k9SakService.gjenåpneHistoriskSak(saksnummer)
     }
 }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerController.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerController.kt
@@ -8,10 +8,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.k9punsj.felles.dto.PeriodeDto
 import no.nav.k9punsj.openapi.OpenApi
 import no.nav.k9punsj.sak.dto.SakInfoDto
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -47,6 +51,96 @@ internal class SakerController {
         summary = "Henter saker",
         security = [SecurityRequirement(name = OpenApi.OAUTH2)]
     )
-    fun hentSaker(@RequestHeader("X-Nav-NorskIdent") norskIdent: String) {
+    fun getHentSaker(@RequestHeader("X-Nav-NorskIdent") norskIdent: String) {
+    }
+
+    @PostMapping(SakerRoutes.Urls.HentSaker, consumes = ["application/json"], produces = ["application/json"])
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Hvis saker hentes",
+                content = [
+                    Content(
+                        array = ArraySchema(
+                            schema = Schema(
+                                implementation = SakInfoDto::class
+                            )
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Internal server error eller saf har fått Internal server error"
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Saksbehandler har ikke tilgang til saker for søker."
+            )
+        ]
+    )
+    @Operation(
+        summary = "Henter saker",
+        security = [SecurityRequirement(name = OpenApi.OAUTH2)]
+    )
+    fun postHentSaker(@RequestBody norskIdent: String) {
+    }
+
+    @PostMapping(SakerRoutes.Urls.HentPerioder, consumes = ["application/json"], produces = ["application/json"])
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Hvis sakens perioder hentes",
+                content = [
+                    Content(
+                        array = ArraySchema(
+                            schema = Schema(
+                                implementation = PeriodeDto::class
+                            )
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Internal server error eller saf har fått Internal server error"
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Saksbehandler har ikke tilgang til saken."
+            )
+        ]
+    )
+    @Operation(
+        summary = "Henter perioder",
+        security = [SecurityRequirement(name = OpenApi.OAUTH2)]
+    )
+    fun hentPerioder(@RequestParam("saksnummer") saksnummer: String) {
+    }
+
+    @PostMapping(SakerRoutes.Urls.GjenåpneHistoriskSak, consumes = ["application/json"], produces = ["application/json"])
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Hvis saken gjenåpnes",
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "Internal server error eller saf har fått Internal server error"
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "Saksbehandler har ikke tilgang til saken."
+            )
+        ]
+    )
+    @Operation(
+        summary = "Gjenåpner historisk sak",
+        security = [SecurityRequirement(name = OpenApi.OAUTH2)]
+    )
+    fun gjenåpneHistoriskSak(@RequestParam("saksnummer") saksnummer: String) {
     }
 }

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerController.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerController.kt
@@ -87,7 +87,7 @@ internal class SakerController {
     fun postHentSaker(@RequestBody norskIdent: String) {
     }
 
-    @PostMapping(SakerRoutes.Urls.HentPerioder, consumes = ["application/json"], produces = ["application/json"])
+    @PostMapping(SakerRoutes.Urls.HentPerioder, produces = ["application/json"])
     @ApiResponses(
         value = [
             ApiResponse(
@@ -120,7 +120,7 @@ internal class SakerController {
     fun hentPerioder(@RequestParam("saksnummer") saksnummer: String) {
     }
 
-    @PostMapping(SakerRoutes.Urls.GjenåpneHistoriskSak, consumes = ["application/json"], produces = ["application/json"])
+    @PostMapping(SakerRoutes.Urls.GjenåpneHistoriskSak, produces = ["application/json"])
     @ApiResponses(
         value = [
             ApiResponse(

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -132,7 +132,7 @@ internal class SakerRoutes(
             RequestContext(currentCoroutineContext(), request) {
                 val saksnummer = request.queryParam("saksnummer").orElseThrow()
 
-                val tilgangsbeslutning = pepClient.harLesetilgangTilSaksnummer(Saksnummer(saksnummer), Urls.HentSaker).tilgangsbeslutning
+                val tilgangsbeslutning = pepClient.harLesetilgangTilSaksnummer(Saksnummer(saksnummer), Urls.HentPerioder).tilgangsbeslutning
                 if (!tilgangsbeslutning.harTilgang) {
                     return@RequestContext ServerResponse
                         .status(HttpStatus.FORBIDDEN)
@@ -143,7 +143,7 @@ internal class SakerRoutes(
                 val perioder = try {
                     sakService.hentPerioderForSaksnummer(saksnummer)
                 } catch (e: Exception) {
-                    logger.error("Feilet med å hente saker.", e)
+                    logger.error("Feilet med å hente perioder.", e)
                     return@RequestContext ServerResponse
                         .status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .json()

--- a/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
+++ b/src/main/kotlin/no/nav/k9punsj/sak/SakerRoutes.kt
@@ -7,10 +7,9 @@ import no.nav.k9punsj.SaksbehandlerRoutes
 import no.nav.k9punsj.domenetjenester.PersonService
 import no.nav.k9punsj.openapi.OasFeil
 import no.nav.k9punsj.tilgangskontroll.AuthenticationHandler
-import no.nav.k9punsj.tilgangskontroll.InnloggetUtils
 import no.nav.k9punsj.tilgangskontroll.abac.IPepClient
 import no.nav.k9punsj.utils.ServerRequestUtils.hentNorskIdentHeader
-import no.nav.sif.abac.kontrakt.abac.dto.SaksnummerDto
+import no.nav.k9punsj.utils.ServerRequestUtils.mapNorskIdent
 import no.nav.sif.abac.kontrakt.person.AktørId
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -36,6 +35,7 @@ internal class SakerRoutes(
     internal object Urls {
         internal const val HentSaker = "/saker/hent"
         internal const val HentPerioder = "/saker/perioder"
+        internal const val GjenåpneHistoriskSak = "/saker/gjenapneHistorisk"
     }
 
     @Bean
@@ -46,10 +46,10 @@ internal class SakerRoutes(
                 val norskIdent = request.hentNorskIdentHeader()
                 val aktørId = personService.finnAktørId(norskIdent)
                 val tilgang = pepClient.sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(
-                        brukerAktørId = AktørId(aktørId),
-                        urlKallet = Urls.HentSaker
-                    )
-                if (!tilgang.tilgangsbeslutning.harTilgang){
+                    brukerAktørId = AktørId(aktørId),
+                    urlKallet = Urls.HentSaker
+                )
+                if (!tilgang.tilgangsbeslutning.harTilgang) {
                     return@RequestContext ServerResponse
                         .status(HttpStatus.FORBIDDEN)
                         .json()
@@ -67,9 +67,9 @@ internal class SakerRoutes(
                 }
 
                 //kallet til sakService returnerer også reserverte saker, de er ikke tilgangssjekket allerede så gjør det her
-                val reserverteSaksnumre = saker.filter { s->s.reservert }.map { s->Saksnummer(s.fagsakId) }
+                val reserverteSaksnumre = saker.filter { s -> s.reservert }.map { s -> Saksnummer(s.fagsakId) }
                 reserverteSaksnumre.forEach {
-                    val tilgangsbeslutning  = pepClient.harLesetilgangTilSaksnummerUtenAuditlogg(it)
+                    val tilgangsbeslutning = pepClient.harLesetilgangTilSaksnummerUtenAuditlogg(it).tilgangsbeslutning
                     if (!tilgangsbeslutning.harTilgang) {
                         return@RequestContext ServerResponse
                             .status(HttpStatus.FORBIDDEN)
@@ -79,7 +79,50 @@ internal class SakerRoutes(
                 }
 
                 return@RequestContext ServerResponse
-                    .status(HttpStatus.OK)
+                    .ok()
+                    .json()
+                    .bodyValueAndAwait(saker)
+            }
+        }
+        POST("/api${Urls.HentSaker}") { request ->
+            RequestContext(currentCoroutineContext(), request) {
+                val norskIdent = request.mapNorskIdent()
+                val aktørId = personService.finnAktørId(norskIdent)
+                val tilgang = pepClient.sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(
+                    brukerAktørId = AktørId(aktørId),
+                    urlKallet = Urls.HentSaker
+                )
+                if (!tilgang.tilgangsbeslutning.harTilgang) {
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.FORBIDDEN)
+                        .json()
+                        .bodyValueAndAwait(tilgang.tilgangsbeslutning.årsakerForIkkeTilgang)
+                }
+
+                val saker = try {
+                    sakService.hentSaker(norskIdent)
+                } catch (e: Exception) {
+                    logger.error("Feilet med å hente saker.", e)
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .json()
+                        .bodyValueAndAwait(OasFeil(e.message))
+                }
+
+                //kallet til sakService returnerer også reserverte saker, de er ikke tilgangssjekket allerede så gjør det her
+                val reserverteSaksnumre = saker.filter { s -> s.reservert }.map { s -> Saksnummer(s.fagsakId) }
+                reserverteSaksnumre.forEach {
+                    val tilgangsbeslutning = pepClient.harLesetilgangTilSaksnummerUtenAuditlogg(it).tilgangsbeslutning
+                    if (!tilgangsbeslutning.harTilgang) {
+                        return@RequestContext ServerResponse
+                            .status(HttpStatus.FORBIDDEN)
+                            .json()
+                            .bodyValueAndAwait(tilgangsbeslutning.årsakerForIkkeTilgang)
+                    }
+                }
+
+                return@RequestContext ServerResponse
+                    .ok()
                     .json()
                     .bodyValueAndAwait(saker)
             }
@@ -89,7 +132,7 @@ internal class SakerRoutes(
             RequestContext(currentCoroutineContext(), request) {
                 val saksnummer = request.queryParam("saksnummer").orElseThrow()
 
-                val tilgangsbeslutning  = pepClient.harLesetilgangTilSaksnummer(Saksnummer(saksnummer), Urls.HentSaker)
+                val tilgangsbeslutning = pepClient.harLesetilgangTilSaksnummer(Saksnummer(saksnummer), Urls.HentSaker).tilgangsbeslutning
                 if (!tilgangsbeslutning.harTilgang) {
                     return@RequestContext ServerResponse
                         .status(HttpStatus.FORBIDDEN)
@@ -111,6 +154,36 @@ internal class SakerRoutes(
                     .ok()
                     .json()
                     .bodyValueAndAwait(perioder)
+            }
+        }
+
+        POST("/api${Urls.GjenåpneHistoriskSak}") { request ->
+            RequestContext(currentCoroutineContext(), request) {
+                val saksnummer = request.queryParam("saksnummer").map(::Saksnummer).orElseThrow()
+
+                val tilgangsbeslutning =
+                    pepClient.harSkrivetilgangTilSaksnummer(saksnummer, Urls.GjenåpneHistoriskSak).tilgangsbeslutning
+                if (!tilgangsbeslutning.harTilgang) {
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.FORBIDDEN)
+                        .json()
+                        .bodyValueAndAwait(tilgangsbeslutning.årsakerForIkkeTilgang)
+                }
+
+                try {
+                    sakService.gjenåpneHistoriskSak(saksnummer)
+                } catch (e: Exception) {
+                    logger.error("Feilet med å gjenåpne historisk sak.", e)
+                    return@RequestContext ServerResponse
+                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .json()
+                        .bodyValueAndAwait(OasFeil(e.message))
+                }
+
+                ServerResponse
+                    .ok()
+                    .json()
+                    .buildAndAwait()
             }
         }
     }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/IPepClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/IPepClient.kt
@@ -1,8 +1,8 @@
 package no.nav.k9punsj.tilgangskontroll.abac
 
 import no.nav.k9.sak.typer.Saksnummer
-import no.nav.sif.abac.kontrakt.abac.resultat.Tilgangsbeslutning
 import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgHistoriskSak
+import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgSporingshint
 import no.nav.sif.abac.kontrakt.person.AktørId
 
 interface IPepClient {
@@ -11,9 +11,11 @@ interface IPepClient {
 
     suspend fun harLesetilgang(fnr: String, urlKallet: String): Boolean
 
-    suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): Tilgangsbeslutning
+    suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint
 
-    suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): Tilgangsbeslutning
+    suspend fun harSkrivetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint
+
+    suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): TilgangsbeslutningOgSporingshint
 
     suspend fun sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(brukerAktørId : AktørId, urlKallet: String): TilgangsbeslutningOgHistoriskSak
 

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/PepClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/PepClient.kt
@@ -7,8 +7,8 @@ import no.nav.k9punsj.idToken
 import no.nav.k9punsj.integrasjoner.pdl.PdlService
 import no.nav.k9punsj.tilgangskontroll.audit.*
 import no.nav.sif.abac.kontrakt.abac.BeskyttetRessursActionAttributt
-import no.nav.sif.abac.kontrakt.abac.resultat.Tilgangsbeslutning
 import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgHistoriskSak
+import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgSporingshint
 import no.nav.sif.abac.kontrakt.person.AktørId
 import no.nav.sif.abac.kontrakt.person.PersonIdent
 import org.springframework.context.annotation.Configuration
@@ -64,15 +64,24 @@ class PepClient(
     /**
      * bare bruk denne der det allerede er auditlogget
      */
-    override suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): Tilgangsbeslutning {
+    override suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): TilgangsbeslutningOgSporingshint {
         return sifAbacPdpKlient.sjekkLesetilgangTilFagsak(saksnummer)
     }
 
-    override suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): Tilgangsbeslutning {
+    override suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint {
         val tilgang = sifAbacPdpKlient.sjekkLesetilgangTilFagsak(saksnummer)
-        if (tilgang.harTilgang){
+        if (tilgang.tilgangsbeslutning.harTilgang) {
             val identTilInnloggetBruker = currentCoroutineContext().idToken().getNavIdent()
-            loggTilAudit(identTilInnloggetBruker, saksnummer, EventClassId.AUDIT_CREATE, TILGANG_SAK, "read", urlKallet)
+            loggTilAudit(identTilInnloggetBruker, saksnummer, EventClassId.AUDIT_ACCESS, TILGANG_SAK, "read", urlKallet)
+        }
+        return tilgang
+    }
+
+    override suspend fun harSkrivetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint {
+        val tilgang = sifAbacPdpKlient.sjekkLesetilgangTilFagsak(saksnummer)
+        if (tilgang.tilgangsbeslutning.harTilgang) {
+            val identTilInnloggetBruker = currentCoroutineContext().idToken().getNavIdent()
+            loggTilAudit(identTilInnloggetBruker, saksnummer, EventClassId.AUDIT_UPDATE, TILGANG_SAK, "update", urlKallet)
         }
         return tilgang
     }

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/PepClient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/PepClient.kt
@@ -78,7 +78,7 @@ class PepClient(
     }
 
     override suspend fun harSkrivetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint {
-        val tilgang = sifAbacPdpKlient.sjekkLesetilgangTilFagsak(saksnummer)
+        val tilgang = sifAbacPdpKlient.sjekkSkrivetilgangTilFagsak(saksnummer)
         if (tilgang.tilgangsbeslutning.harTilgang) {
             val identTilInnloggetBruker = currentCoroutineContext().idToken().getNavIdent()
             loggTilAudit(identTilInnloggetBruker, saksnummer, EventClassId.AUDIT_UPDATE, TILGANG_SAK, "update", urlKallet)

--- a/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/SifAbacPdpKlient.kt
+++ b/src/main/kotlin/no/nav/k9punsj/tilgangskontroll/abac/SifAbacPdpKlient.kt
@@ -11,7 +11,6 @@ import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
 import no.nav.helse.dusseldorf.oauth2.client.CachedAccessTokenClient
 import no.nav.k9.sak.typer.Saksnummer
 import no.nav.k9punsj.felles.RestKallException
-import no.nav.k9punsj.felles.dto.SaksnummerDto
 import no.nav.k9punsj.hentCallId
 import no.nav.k9punsj.idToken
 import no.nav.k9punsj.utils.objectMapper
@@ -22,6 +21,7 @@ import no.nav.sif.abac.kontrakt.abac.dto.PersonerOperasjonDto
 import no.nav.sif.abac.kontrakt.abac.dto.SaksnummerOperasjonDto
 import no.nav.sif.abac.kontrakt.abac.resultat.Tilgangsbeslutning
 import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgHistoriskSak
+import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgSporingshint
 import no.nav.sif.abac.kontrakt.person.AktørId
 import no.nav.sif.abac.kontrakt.person.PersonIdent
 import org.slf4j.LoggerFactory
@@ -49,15 +49,21 @@ class SifAbacPdpKlient(
         return om.readValue<Tilgangsbeslutning>(response).harTilgang()
     }
 
-    suspend fun sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(brukerAktørId: AktørId): TilgangsbeslutningOgHistoriskSak{
+    suspend fun sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(brukerAktørId: AktørId): TilgangsbeslutningOgHistoriskSak {
         val response = httpPostMedOboToken(om.writeValueAsString(brukerAktørId), "${baseUrl}/brukers-saker-med-historisk-flagg")
         return om.readValue<TilgangsbeslutningOgHistoriskSak>(response)
     }
 
-    suspend fun sjekkLesetilgangTilFagsak(saksnummer: Saksnummer): Tilgangsbeslutning {
+    suspend fun sjekkLesetilgangTilFagsak(saksnummer: Saksnummer): TilgangsbeslutningOgSporingshint {
         val request = SaksnummerOperasjonDto(no.nav.sif.abac.kontrakt.abac.dto.SaksnummerDto(saksnummer.verdi), OperasjonDto(ResourceType.FAGSAK, BeskyttetRessursActionAttributt.READ, setOf()))
-        val response = httpPostMedOboToken(om.writeValueAsString(request), "${baseUrl}/sak")
-        return om.readValue<Tilgangsbeslutning>(response)
+        val response = httpPostMedOboToken(om.writeValueAsString(request), "${baseUrl}/sak-sporingshint")
+        return om.readValue<TilgangsbeslutningOgSporingshint>(response)
+    }
+
+    suspend fun sjekkSkrivetilgangTilFagsak(saksnummer: Saksnummer): TilgangsbeslutningOgSporingshint {
+        val request = SaksnummerOperasjonDto(no.nav.sif.abac.kontrakt.abac.dto.SaksnummerDto(saksnummer.verdi), OperasjonDto(ResourceType.FAGSAK, BeskyttetRessursActionAttributt.UPDATE, setOf()))
+        val response = httpPostMedOboToken(om.writeValueAsString(request), "${baseUrl}/sak-sporingshint")
+        return om.readValue<TilgangsbeslutningOgSporingshint>(response)
     }
 
     private suspend fun httpPostMedOboToken(body: String, url: String): String {

--- a/src/main/kotlin/no/nav/k9punsj/utils/ServerRequestUtils.kt
+++ b/src/main/kotlin/no/nav/k9punsj/utils/ServerRequestUtils.kt
@@ -13,6 +13,9 @@ object ServerRequestUtils {
     internal fun ServerRequest.hentNorskIdentHeader(): String =
         headers().header("X-Nav-NorskIdent").first()!!
 
+    internal suspend fun ServerRequest.mapNorskIdent(): String =
+        body(BodyExtractors.toMono(String::class.java)).awaitFirst()
+
     internal suspend fun ServerRequest.mapNySøknad(): OpprettNySøknad =
         body(BodyExtractors.toMono(OpprettNySøknad::class.java)).awaitFirst()
 

--- a/src/test/kotlin/no/nav/k9punsj/abac/AlltidTilgangPepClient.kt
+++ b/src/test/kotlin/no/nav/k9punsj/abac/AlltidTilgangPepClient.kt
@@ -5,9 +5,11 @@ import no.nav.k9punsj.LokalProfil
 import no.nav.k9punsj.tilgangskontroll.abac.IPepClient
 import no.nav.sif.abac.kontrakt.abac.resultat.Tilgangsbeslutning
 import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgHistoriskSak
+import no.nav.sif.abac.kontrakt.abac.resultat.TilgangsbeslutningOgSporingshint
 import no.nav.sif.abac.kontrakt.person.AktørId
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
+import kotlin.collections.emptyMap
 
 @Component
 @LokalProfil
@@ -15,8 +17,9 @@ import org.springframework.stereotype.Component
 internal class AlltidTilgangPepClient : IPepClient {
     override suspend fun harLesetilgang(fnr: List<String>, fnrForSporingslogg: List<String>, urlKallet: String) = true
     override suspend fun harLesetilgang(fnr: String, urlKallet: String) = true
-    override suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String) = Tilgangsbeslutning(true, emptySet())
-    override suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): Tilgangsbeslutning = Tilgangsbeslutning(true, emptySet())
+    override suspend fun harLesetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String) = TilgangsbeslutningOgSporingshint(Tilgangsbeslutning(true, emptySet()), emptySet())
+    override suspend fun harSkrivetilgangTilSaksnummer(saksnummer: Saksnummer, urlKallet: String): TilgangsbeslutningOgSporingshint = TilgangsbeslutningOgSporingshint(Tilgangsbeslutning(true, emptySet()), emptySet())
+    override suspend fun harLesetilgangTilSaksnummerUtenAuditlogg(saksnummer: Saksnummer): TilgangsbeslutningOgSporingshint = TilgangsbeslutningOgSporingshint(Tilgangsbeslutning(true, emptySet()), emptySet())
     override suspend fun sjekkTilgangTilBrukersSakerOgGiInformasjonOmHistoriskSak(brukerAktørId: AktørId, urlKallet: String): TilgangsbeslutningOgHistoriskSak = TilgangsbeslutningOgHistoriskSak(Tilgangsbeslutning(true, emptySet()), emptyMap())
     override suspend fun harSendeInnTilgang(fnr: String, urlKallet: String) = true
     override suspend fun harSendeInnTilgang(fnr: List<String>, fnrForSporingslogg: List<String>, urlKallet: String) = true

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/LokalK9SakService.kt
@@ -1,8 +1,6 @@
 package no.nav.k9punsj.rest.eksternt.k9sak
 
 import no.nav.k9.kodeverk.dokument.Brevkode
-import no.nav.k9.sak.kontrakt.fagsak.FagsakDto
-import no.nav.k9.sak.kontrakt.fagsak.FagsakSøkeresultatDto
 import no.nav.k9.sak.kontrakt.opplæringspenger.godkjentopplaeringsinstitusjon.GodkjentOpplæringsinstitusjonDto
 import no.nav.k9.sak.typer.Periode
 import no.nav.k9.sak.typer.Saksnummer
@@ -254,4 +252,6 @@ class LokalK9SakService : K9SakService {
             ),
         )
     }
+
+    override suspend fun gjenåpneHistoriskSak(saksnummer: Saksnummer) {}
 }

--- a/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
+++ b/src/test/kotlin/no/nav/k9punsj/rest/eksternt/k9sak/TestK9SakService.kt
@@ -140,4 +140,6 @@ internal class TestK9SakService : K9SakService {
             ),
         )
     }
+
+    override suspend fun gjenåpneHistoriskSak(saksnummer: Saksnummer) {}
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Saksbehandler kan få behov for å gjenåpne en historisk sak manuelt, for å kunne journalføre dokumenter på den.

### Løsning
Legger til endepunkt for å kunne manuelt gjenåpne en historisk sak i k9-sak.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
